### PR TITLE
feat(spi-34): add registry scaffold command for new package entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,5 +63,8 @@ Optional flags:
 - `--output-root <dir>` to scaffold outside `index/` (useful for tests/dry runs)
 - `--license <value>` and `--homepage <url>` to replace defaults
 - `--binary-name <name>` and `--binary-path <path>` to customize executable mapping
+- `--force` to overwrite an existing `<version>.toml` (default is safe no-overwrite)
 
 After scaffolding, replace placeholders with real values and then sign the manifest sidecar (`<version>.toml.sig`) as part of the normal publication flow.
+
+Validator runtime note: Python 3.11+ works out of the box (`tomllib`). On Python 3.10, install `tomli` so validation can parse TOML.

--- a/scripts/registry-scaffold-entry.sh
+++ b/scripts/registry-scaffold-entry.sh
@@ -13,7 +13,8 @@ Usage:
     [--license <license>] \
     [--homepage <homepage-url>] \
     [--binary-name <binary-name>] \
-    [--binary-path <binary-path>]
+    [--binary-path <binary-path>] \
+    [--force]
 EOF
 }
 
@@ -26,6 +27,7 @@ LICENSE_VALUE="TODO_LICENSE"
 HOMEPAGE="TODO_HOMEPAGE"
 BINARY_NAME=""
 BINARY_PATH="TODO_BINARY_PATH"
+FORCE=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -65,6 +67,10 @@ while [[ $# -gt 0 ]]; do
       BINARY_PATH="$2"
       shift 2
       ;;
+    --force)
+      FORCE=1
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -97,6 +103,12 @@ fi
 OUT_DIR="${OUTPUT_ROOT%/}/$NAME"
 OUT_FILE="$OUT_DIR/$VERSION.toml"
 TMP_FILE="$(mktemp)"
+
+if [[ -e "$OUT_FILE" && "$FORCE" -ne 1 ]]; then
+  rm -f "$TMP_FILE"
+  echo "Refusing to overwrite existing manifest: $OUT_FILE (use --force to overwrite)" >&2
+  exit 1
+fi
 
 cat > "$TMP_FILE" <<EOF
 name = "$NAME"

--- a/scripts/registry-validate-entry.py
+++ b/scripts/registry-validate-entry.py
@@ -7,7 +7,17 @@ import argparse
 import sys
 from pathlib import Path
 
-import tomllib
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover - exercised on Python 3.10
+    try:
+        import tomli as tomllib  # type: ignore[no-redef]
+    except ModuleNotFoundError as exc:  # pragma: no cover
+        print(
+            "Validation failed: Python 3.11+ required (or install tomli for Python 3.10)",
+            file=sys.stderr,
+        )
+        raise SystemExit(1) from exc
 
 
 class ValidationError(Exception):


### PR DESCRIPTION
Implements SPI-34 (registry maintainer tooling for scaffolding package entries).

## What changed
- Added `scripts/registry-scaffold-entry.sh`
  - scaffolds deterministic `index/<name>/<version>.toml`
  - auto-populates placeholder sections for checksum/signature/source metadata
  - validates generated output before writing
- Added `scripts/registry-validate-entry.py`
  - lightweight schema/shape validation for scaffolded manifests
- Added tests: `tests/test_registry_scaffold.py`
  - happy-path template generation
  - validation failure aborts write
- Updated maintainer docs in `README.md` with scaffold workflow and options.

## Acceptance mapping
- scaffold command for new package entries ✅
- template placeholders for checksum/signature/source metadata ✅
- pre-write validation ✅
- maintainer workflow docs ✅
- tests for generation and validation-failure path ✅

## Verification
- `python3 -m unittest tests/test_registry_scaffold.py`
- `python3 scripts/registry-validate-entry.py index/ripgrep/15.1.0.toml`
