### PR TITLE
ci(registry): add Windows smoke-install coverage and failure hints (SPI-38)

### DIFF
--- a/.github/workflows/registry-quality-gate.yml
+++ b/.github/workflows/registry-quality-gate.yml
@@ -13,6 +13,41 @@ on:
   workflow_dispatch:
 
 jobs:
+  detect-pr-manifests:
+    name: Detect PR Manifest Changes
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      manifests_json: ${{ steps.changed.outputs.manifests_json }}
+      manifest_count: ${{ steps.changed.outputs.manifest_count }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Collect changed manifests
+        id: changed
+        env:
+          REGISTRY_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          mapfile -t manifests < <(REGISTRY_BASE_SHA="$REGISTRY_BASE_SHA" ./scripts/registry-changed-manifests.sh)
+
+          if [[ "${#manifests[@]}" -eq 0 ]]; then
+            echo "manifests_json=[]" >> "$GITHUB_OUTPUT"
+            echo "manifest_count=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          manifests_json="$(
+            printf '%s\n' "${manifests[@]}" \
+              | python3 -c 'import json, sys; print(json.dumps([line.strip() for line in sys.stdin if line.strip()]))'
+          )"
+
+          echo "manifests_json=$manifests_json" >> "$GITHUB_OUTPUT"
+          echo "manifest_count=${#manifests[@]}" >> "$GITHUB_OUTPUT"
+
   preflight:
     name: Validate Registry Manifests
     runs-on: ubuntu-latest
@@ -28,6 +63,7 @@ jobs:
         env:
           REGISTRY_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           REGISTRY_REQUIRE_SIGNATURES: '0'
+          REGISTRY_PREFLIGHT_SKIP_SMOKE: '1'
         run: ./scripts/registry-preflight.sh
 
       - name: Registry preflight (full scan)
@@ -35,3 +71,44 @@ jobs:
         env:
           REGISTRY_PREFLIGHT_ALL: '1'
         run: ./scripts/registry-preflight.sh
+
+  pr-smoke:
+    name: PR Smoke Install (${{ matrix.os }})
+    if: github.event_name == 'pull_request'
+    needs:
+      - detect-pr-manifests
+      - preflight
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Smoke install (changed manifests)
+        if: needs.detect-pr-manifests.outputs.manifest_count != '0'
+        shell: bash
+        env:
+          MANIFESTS_JSON: ${{ needs.detect-pr-manifests.outputs.manifests_json }}
+        run: |
+          mapfile -t manifests < <(
+            python -c 'import json, os; [print(item) for item in json.loads(os.environ["MANIFESTS_JSON"])]'
+          )
+          python scripts/registry-smoke-install.py "${manifests[@]}"
+
+      - name: Skip changed-manifest smoke (none changed)
+        if: needs.detect-pr-manifests.outputs.manifest_count == '0'
+        shell: bash
+        run: echo "No changed manifests in this PR."
+
+      - name: Windows package-layout canary
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: python scripts/registry-smoke-install.py --app-bundle-canary

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ CI enforces a registry quality gate that validates changed manifests and runs sm
 
 - Schema and required metadata checks for each changed `index/<package>/<version>.toml`
 - Checksum + signature format checks (`sha256` fields and matching `.toml.sig` sidecar)
-- Smoke-install path that downloads one artifact per changed manifest, verifies SHA-256, and validates extracted binaries
+- PR smoke-install matrix on `ubuntu-latest` and `windows-latest` for changed manifests
+- Windows package-layout canary via `python scripts/registry-smoke-install.py --app-bundle-canary` (currently validates direct `.exe` layout with `index/jq/1.8.1.toml`)
+- Smoke-install path that downloads one artifact per selected manifest, verifies SHA-256, and validates extracted binaries
 
 Run the same checks locally:
 
@@ -64,6 +66,9 @@ Useful variants:
 ```bash
 # Full scan of all manifests (matches push/manual workflow behavior)
 REGISTRY_PREFLIGHT_ALL=1 ./scripts/registry-preflight.sh
+
+# Full scan without smoke-install (useful when iterating on validation logic only)
+REGISTRY_PREFLIGHT_ALL=1 REGISTRY_PREFLIGHT_SKIP_SMOKE=1 ./scripts/registry-preflight.sh
 
 # Validate only manifests changed from a specific base commit (matches PR workflow behavior)
 REGISTRY_BASE_SHA=<base-sha> ./scripts/registry-preflight.sh

--- a/scripts/registry-preflight.sh
+++ b/scripts/registry-preflight.sh
@@ -20,6 +20,10 @@ if [[ "${REGISTRY_REQUIRE_SIGNATURES:-1}" == "0" ]]; then
 fi
 
 python3 "$repo_root/scripts/registry-validate.py" "${validate_args[@]}" "${manifests[@]}"
-python3 "$repo_root/scripts/registry-smoke-install.py" "${manifests[@]}"
+if [[ "${REGISTRY_PREFLIGHT_SKIP_SMOKE:-0}" != "1" ]]; then
+  python3 "$repo_root/scripts/registry-smoke-install.py" "${manifests[@]}"
+else
+  echo "Skipping smoke-install checks (REGISTRY_PREFLIGHT_SKIP_SMOKE=1)."
+fi
 
 echo "Registry preflight complete."

--- a/tests/test_registry_smoke_install.py
+++ b/tests/test_registry_smoke_install.py
@@ -1,0 +1,93 @@
+import hashlib
+import importlib.util
+import io
+import tempfile
+import textwrap
+import unittest
+import zipfile
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "registry-smoke-install.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("registry_smoke_install", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load script module from {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class RegistrySmokeInstallTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.smoke = load_module()
+
+    def test_missing_binary_failure_includes_package_binary_and_hint(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="smoke-test-") as tmp:
+            tmp_path = Path(tmp)
+            payload_path = tmp_path / "empty.zip"
+            with zipfile.ZipFile(payload_path, "w"):
+                pass
+            payload_bytes = payload_path.read_bytes()
+            payload_sha = hashlib.sha256(payload_bytes).hexdigest()
+
+            manifest_path = tmp_path / "demo.toml"
+            manifest_path.write_text(
+                textwrap.dedent(
+                    f"""
+                    name = "demo"
+                    version = "1.2.3"
+
+                    [[artifacts]]
+                    target = "x86_64-pc-windows-msvc"
+                    url = "https://example.invalid/demo.zip"
+                    sha256 = "{payload_sha}"
+                    archive = "zip"
+                    strip_components = 0
+
+                    [[artifacts.binaries]]
+                    name = "demo"
+                    path = "demo.exe"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            def fake_download(_url: str, dest: Path) -> None:
+                dest.write_bytes(payload_bytes)
+
+            with mock.patch.object(self.smoke, "download", side_effect=fake_download):
+                ok, message = self.smoke.smoke_manifest(manifest_path)
+
+        self.assertFalse(ok)
+        self.assertIn("demo@1.2.3", message)
+        self.assertIn("demo.exe", message)
+        self.assertIn("hint:", message.lower())
+
+    def test_main_accepts_app_bundle_canary_without_explicit_manifests(self) -> None:
+        canary_calls = []
+
+        def fake_smoke_manifest(path: Path) -> tuple[bool, str]:
+            canary_calls.append(path)
+            return True, f"{path}: smoke-install ok"
+
+        with mock.patch.object(self.smoke, "smoke_manifest", side_effect=fake_smoke_manifest):
+            with mock.patch("sys.argv", ["registry-smoke-install.py", "--app-bundle-canary"]):
+                stdout = io.StringIO()
+                stderr = io.StringIO()
+                with redirect_stdout(stdout), redirect_stderr(stderr):
+                    rc = self.smoke.main()
+
+        self.assertEqual(rc, 0, msg=stderr.getvalue())
+        self.assertEqual(len(canary_calls), 1, msg=f"unexpected calls: {canary_calls}")
+        self.assertEqual(canary_calls[0], REPO_ROOT / "index" / "jq" / "1.8.1.toml")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- PR smoke matrix now includes  alongside 
- Windows canary smoke validates  direct  layout via 
- Smoke failures now include , failing binary path, and remediation hint
- Add  for local iteration
- Add tests for new message contract and 
- Update README with Windows validation behavior

## Testing
-  ✅
-  ✅
- Running registry preflight on 16 manifest(s)...
 - index/crosspack/0.0.2.toml
 - index/crosspack/0.0.3.toml
 - index/crosspack/0.0.4.toml
 - index/crosspack/0.3.1.toml
 - index/crosspack/0.4.0.toml
 - index/crosspack/0.4.1.toml
 - index/crosspack/0.5.0.toml
 - index/crosspack/0.6.0.toml
 - index/crosspack/0.7.0.toml
 - index/crosspack/0.7.1.toml
 - index/crosspack/0.7.3.toml
 - index/fd/10.3.0.toml
 - index/fzf/0.68.0.toml
 - index/jq/1.8.1.toml
 - index/neovide/0.15.2.toml
 - index/ripgrep/15.1.0.toml
Validated 16 manifest(s): schema, metadata, checksum, and signature format checks passed.
Skipping smoke-install checks (REGISTRY_PREFLIGHT_SKIP_SMOKE=1).
Registry preflight complete. ✅

Closes SPI-38