### PR TITLE
fix(registry): support bin archive artifacts for jq

### DIFF
--- a/index/jq/1.8.1.toml
+++ b/index/jq/1.8.1.toml
@@ -7,6 +7,7 @@ homepage = "https://github.com/jqlang/jq"
 target = "x86_64-unknown-linux-gnu"
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-linux-amd64"
 sha256 = "020468de7539ce70ef1bceaf7cde2e8c4f2ca6c3afb84642aabc5c97d9fc2a0d"
+archive = "bin"
 
 [[artifacts.binaries]]
 name = "jq"
@@ -16,6 +17,7 @@ path = "jq-linux-amd64"
 target = "aarch64-unknown-linux-gnu"
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-linux-arm64"
 sha256 = "6bc62f25981328edd3cfcfe6fe51b073f2d7e7710d7ef7fcdac28d4e384fc3d4"
+archive = "bin"
 
 [[artifacts.binaries]]
 name = "jq"
@@ -25,6 +27,7 @@ path = "jq-linux-arm64"
 target = "x86_64-apple-darwin"
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-macos-amd64"
 sha256 = "e80dbe0d2a2597e3c11c404f03337b981d74b4a8504b70586c354b7697a7c27f"
+archive = "bin"
 
 [[artifacts.binaries]]
 name = "jq"
@@ -34,6 +37,7 @@ path = "jq-macos-amd64"
 target = "aarch64-apple-darwin"
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-macos-arm64"
 sha256 = "a9fe3ea2f86dfc72f6728417521ec9067b343277152b114f4e98d8cb0e263603"
+archive = "bin"
 
 [[artifacts.binaries]]
 name = "jq"

--- a/scripts/registry-validate.py
+++ b/scripts/registry-validate.py
@@ -98,11 +98,17 @@ def validate_manifest(path: Path, errors: list[str], require_signatures: bool) -
             err(errors, path, f"{prefix}.sha256 must be 64 hex characters")
 
         archive = artifact.get("archive")
-        if archive is not None and archive not in {"tar.gz", "zip", "tar.xz", "tgz"}:
+        if archive is not None and archive not in {
+            "tar.gz",
+            "zip",
+            "tar.xz",
+            "tgz",
+            "bin",
+        }:
             err(
                 errors,
                 path,
-                f"{prefix}.archive must be one of tar.gz, zip, tar.xz, tgz",
+                f"{prefix}.archive must be one of tar.gz, zip, tar.xz, tgz, bin",
             )
 
         strip_components = artifact.get("strip_components")


### PR DESCRIPTION
## Summary
- add explicit `archive = \"bin\"` for jq artifacts that use extensionless release asset URLs
- update registry validation to allow `bin` as a supported archive kind
- update smoke-install handling so `archive = \"bin\"` is treated as direct binary payload copy

## Test Plan
- ./scripts/registry-preflight.sh