### PR TITLE
chore(registry): add wave-1 high-impact package manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,16 @@ Current artifact coverage in this registry:
 - `fd@10.3.0`: linux (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`), darwin (`x86_64-apple-darwin`, `aarch64-apple-darwin`), windows (`x86_64-pc-windows-msvc`, `aarch64-pc-windows-msvc`)
 - `fzf@0.68.0`: linux (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`), darwin (`x86_64-apple-darwin`, `aarch64-apple-darwin`), windows (`x86_64-pc-windows-msvc`, `aarch64-pc-windows-msvc`)
 - `jq@1.8.1`: linux (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`), darwin (`x86_64-apple-darwin`, `aarch64-apple-darwin`), windows (`x86_64-pc-windows-msvc`)
+- `gh@2.87.3`: linux (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`), darwin (`x86_64-apple-darwin`, `aarch64-apple-darwin`), windows (`x86_64-pc-windows-msvc`)
+- `lazygit@0.59.0`: linux (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`), darwin (`x86_64-apple-darwin`, `aarch64-apple-darwin`), windows (`x86_64-pc-windows-msvc`)
+- `uv@0.10.6`: linux (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`), darwin (`x86_64-apple-darwin`, `aarch64-apple-darwin`), windows (`x86_64-pc-windows-msvc`)
+- `starship@1.24.2`: linux (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-musl`), darwin (`x86_64-apple-darwin`, `aarch64-apple-darwin`), windows (`x86_64-pc-windows-msvc`)
+- `bat@0.26.1`: linux (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`), darwin (`x86_64-apple-darwin`, `aarch64-apple-darwin`), windows (`x86_64-pc-windows-msvc`)
+- `delta@0.18.2`: linux (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`), darwin (`x86_64-apple-darwin`, `aarch64-apple-darwin`), windows (`x86_64-pc-windows-msvc`)
 
 Caveat: `crosspack@0.0.3` does not yet publish official `aarch64-pc-windows-msvc` release assets.
+
+Caveat: `starship@1.24.2` currently ships `aarch64-unknown-linux-musl` (not `aarch64-unknown-linux-gnu`) in this registry.
 
 ## Package Update and Rollback Procedure
 

--- a/index/bat/0.26.1.toml
+++ b/index/bat/0.26.1.toml
@@ -1,0 +1,59 @@
+name = "bat"
+version = "0.26.1"
+license = "Apache-2.0 OR MIT"
+homepage = "https://github.com/sharkdp/bat"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/sharkdp/bat/releases/download/v0.26.1/bat-v0.26.1-x86_64-unknown-linux-gnu.tar.gz"
+sha256 = "726f04c8f576a7fd18b7634f1bbf2f915c43494c1c0f013baa3287edb0d5a2a3"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "bat"
+path = "bat"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/sharkdp/bat/releases/download/v0.26.1/bat-v0.26.1-aarch64-unknown-linux-gnu.tar.gz"
+sha256 = "422eb73e11c854fddd99f5ca8461c2f1d6e6dce0a2a8c3d5daade5ffcb6564aa"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "bat"
+path = "bat"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/sharkdp/bat/releases/download/v0.26.1/bat-v0.26.1-x86_64-apple-darwin.tar.gz"
+sha256 = "830d63b0bba1fa040542ec569e3cf77f60d3356b9de75116a344b061e0894245"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "bat"
+path = "bat"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/sharkdp/bat/releases/download/v0.26.1/bat-v0.26.1-aarch64-apple-darwin.tar.gz"
+sha256 = "e30beff26779c9bf60bb541e1d79046250cb74378f2757f8eb250afddb19e114"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "bat"
+path = "bat"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/sharkdp/bat/releases/download/v0.26.1/bat-v0.26.1-x86_64-pc-windows-msvc.zip"
+sha256 = "0f729b4b6f5f28d395c641eacc2e9ff68d0096b85aa0eec344aa62425144b69b"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "bat"
+path = "bat.exe"

--- a/index/delta/0.18.2.toml
+++ b/index/delta/0.18.2.toml
@@ -1,0 +1,59 @@
+name = "delta"
+version = "0.18.2"
+license = "MIT"
+homepage = "https://github.com/dandavison/delta"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/dandavison/delta/releases/download/0.18.2/delta-0.18.2-x86_64-unknown-linux-gnu.tar.gz"
+sha256 = "99607c43238e11a77fe90a914d8c2d64961aff84b60b8186c1b5691b39955b0f"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "delta"
+path = "delta"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/dandavison/delta/releases/download/0.18.2/delta-0.18.2-aarch64-unknown-linux-gnu.tar.gz"
+sha256 = "adf7674086daa4582f598f74ce9caa6b70c1ba8f4a57d2911499b37826b014f9"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "delta"
+path = "delta"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/dandavison/delta/releases/download/0.18.2/delta-0.18.2-x86_64-apple-darwin.tar.gz"
+sha256 = "e9b5c4a9e73d2119c687e074f0d97f188e30e5fe8ae0e6d455755f74bb5cc0cf"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "delta"
+path = "delta"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/dandavison/delta/releases/download/0.18.2/delta-0.18.2-aarch64-apple-darwin.tar.gz"
+sha256 = "6ba38dce9f91ee1b9a24aa4aede1db7195258fe176c3f8276ae2d4457d8170a0"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "delta"
+path = "delta"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/dandavison/delta/releases/download/0.18.2/delta-0.18.2-x86_64-pc-windows-msvc.zip"
+sha256 = "6ea59864091b4cfca89d9ee38388ff1a3ccdc8244b6e1cdd5201259de89b0b06"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "delta"
+path = "delta.exe"

--- a/index/gh/2.87.3.toml
+++ b/index/gh/2.87.3.toml
@@ -1,0 +1,59 @@
+name = "gh"
+version = "2.87.3"
+license = "MIT"
+homepage = "https://github.com/cli/cli"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/cli/cli/releases/download/v2.87.3/gh_2.87.3_linux_amd64.tar.gz"
+sha256 = "c6e5537631fca45f277ef405ce8751d139b491e9402cc20891a003525a8773b2"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "gh"
+path = "bin/gh"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/cli/cli/releases/download/v2.87.3/gh_2.87.3_linux_arm64.tar.gz"
+sha256 = "5f5d89563bf26751e2173b37e594065504e85b6b781c1f1832d24bf2c2b4554f"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "gh"
+path = "bin/gh"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/cli/cli/releases/download/v2.87.3/gh_2.87.3_macOS_amd64.zip"
+sha256 = "7b8d5495fe9689494b1c69559c0d28209bc057bb028008e903ec4b3e19bd8c75"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "gh"
+path = "bin/gh"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/cli/cli/releases/download/v2.87.3/gh_2.87.3_macOS_arm64.zip"
+sha256 = "dedfc6f569e9dbc5b92d47dce44acadbdf5b6b7a861510db0c748dfac55002f6"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "gh"
+path = "bin/gh"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/cli/cli/releases/download/v2.87.3/gh_2.87.3_windows_amd64.zip"
+sha256 = "c590bcb488f80a85c8febd5cde27edd68fdd481bd004aaf9adc50dcf1b21c09c"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "gh"
+path = "bin/gh.exe"

--- a/index/lazygit/0.59.0.toml
+++ b/index/lazygit/0.59.0.toml
@@ -1,0 +1,59 @@
+name = "lazygit"
+version = "0.59.0"
+license = "MIT"
+homepage = "https://github.com/jesseduffield/lazygit"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/jesseduffield/lazygit/releases/download/v0.59.0/lazygit_0.59.0_linux_x86_64.tar.gz"
+sha256 = "264283f40a40c899d702a338b20622f690221f753f03bac827c1f34e91f516c2"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "lazygit"
+path = "lazygit"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/jesseduffield/lazygit/releases/download/v0.59.0/lazygit_0.59.0_linux_arm64.tar.gz"
+sha256 = "a334a6c125169f21942f1a8b02043932575547a6250a1a734d62111efd92aa8f"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "lazygit"
+path = "lazygit"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/jesseduffield/lazygit/releases/download/v0.59.0/lazygit_0.59.0_darwin_x86_64.tar.gz"
+sha256 = "365db34a92d017f7e77fe03aa461a921c6a31832fa9d427a7b06c86732821f55"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "lazygit"
+path = "lazygit"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/jesseduffield/lazygit/releases/download/v0.59.0/lazygit_0.59.0_darwin_arm64.tar.gz"
+sha256 = "cdd42e86b16b3bc21ec5cbe4be92d688e39f3806b53b63c54d1af4f498302ed8"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "lazygit"
+path = "lazygit"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/jesseduffield/lazygit/releases/download/v0.59.0/lazygit_0.59.0_windows_x86_64.zip"
+sha256 = "3f2c43d4596498ca4e1c31c0430e4a2e015624d82ea25bb306c8695e6613d912"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "lazygit"
+path = "lazygit.exe"

--- a/index/starship/1.24.2.toml
+++ b/index/starship/1.24.2.toml
@@ -1,0 +1,59 @@
+name = "starship"
+version = "1.24.2"
+license = "ISC"
+homepage = "https://github.com/starship/starship"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/starship/starship/releases/download/v1.24.2/starship-x86_64-unknown-linux-gnu.tar.gz"
+sha256 = "3f12f61883ff324c1dbe7b885fa125d5490960e5cad6a12eeaa34695ec1b5744"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "starship"
+path = "starship"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-musl"
+url = "https://github.com/starship/starship/releases/download/v1.24.2/starship-aarch64-unknown-linux-musl.tar.gz"
+sha256 = "56b9ff412bbf374d29b99e5ac09a849124cb37a0a13121e8470df32de53c1ea6"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "starship"
+path = "starship"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/starship/starship/releases/download/v1.24.2/starship-x86_64-apple-darwin.tar.gz"
+sha256 = "237beb10cc970c4361536e9f9f434dfed755f8282c5cd951b6a7e3fcbda8e779"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "starship"
+path = "starship"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/starship/starship/releases/download/v1.24.2/starship-aarch64-apple-darwin.tar.gz"
+sha256 = "d3a0da21374962625a2ee992110979bc1fa33424d7b6aea58a70405e26544fd9"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "starship"
+path = "starship"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/starship/starship/releases/download/v1.24.2/starship-x86_64-pc-windows-msvc.zip"
+sha256 = "d38424c595320e9639a276666347d5e44cb004de3972f40b9a5a1a6b88537f29"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "starship"
+path = "starship.exe"

--- a/index/uv/0.10.6.toml
+++ b/index/uv/0.10.6.toml
@@ -1,0 +1,79 @@
+name = "uv"
+version = "0.10.6"
+license = "MIT OR Apache-2.0"
+homepage = "https://github.com/astral-sh/uv"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/astral-sh/uv/releases/download/0.10.6/uv-x86_64-unknown-linux-gnu.tar.gz"
+sha256 = "aaa402e19d14a6b9a4267fcf4ec35380f804c68923525cea67cd6ee05bb4e930"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "uv"
+path = "uv"
+
+[[artifacts.binaries]]
+name = "uvx"
+path = "uvx"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/astral-sh/uv/releases/download/0.10.6/uv-aarch64-unknown-linux-gnu.tar.gz"
+sha256 = "9380705294a85e3e634570abddd5b2577900c1873c29b790c7abc56a81dce4bc"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "uv"
+path = "uv"
+
+[[artifacts.binaries]]
+name = "uvx"
+path = "uvx"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/astral-sh/uv/releases/download/0.10.6/uv-x86_64-apple-darwin.tar.gz"
+sha256 = "d7647571fb17a5107d4d23cc190418039c157fd7361ddb59bc6f8127a49e3eac"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "uv"
+path = "uv"
+
+[[artifacts.binaries]]
+name = "uvx"
+path = "uvx"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/astral-sh/uv/releases/download/0.10.6/uv-aarch64-apple-darwin.tar.gz"
+sha256 = "3993249d8f51deaf34cfce037e57e294e82267ff1f9dc45b7983a17afaf065b4"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "uv"
+path = "uv"
+
+[[artifacts.binaries]]
+name = "uvx"
+path = "uvx"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/astral-sh/uv/releases/download/0.10.6/uv-x86_64-pc-windows-msvc.zip"
+sha256 = "b27eb789f281e398a82197477de727fc8faf08605152115686da2c3cba0d25f7"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "uv"
+path = "uv.exe"
+
+[[artifacts.binaries]]
+name = "uvx"
+path = "uvx.exe"


### PR DESCRIPTION
## Summary
- add six new high-impact package manifests: `gh`, `lazygit`, `uv`, `starship`, `bat`, and `delta`
- include Linux/macOS/Windows artifacts, checksums, archive metadata, and binary mappings for each manifest
- update `README.md` platform coverage list and document the `starship` aarch64 Linux musl caveat

## Verification
- `python3 scripts/registry-validate-entry.py index/gh/2.87.3.toml`
- `python3 scripts/registry-validate-entry.py index/lazygit/0.59.0.toml`
- `python3 scripts/registry-validate-entry.py index/uv/0.10.6.toml`
- `python3 scripts/registry-validate-entry.py index/starship/1.24.2.toml`
- `python3 scripts/registry-validate-entry.py index/bat/0.26.1.toml`
- `python3 scripts/registry-validate-entry.py index/delta/0.18.2.toml`
- `python3 scripts/registry-validate.py --allow-missing-signatures index/gh/2.87.3.toml index/lazygit/0.59.0.toml index/uv/0.10.6.toml index/starship/1.24.2.toml index/bat/0.26.1.toml index/delta/0.18.2.toml`
- `REGISTRY_REQUIRE_SIGNATURES=0 ./scripts/registry-preflight.sh`
- `REGISTRY_PREFLIGHT_ALL=1 REGISTRY_REQUIRE_SIGNATURES=0 ./scripts/registry-preflight.sh`