### PR TITLE
chore(registry): add high-impact GUI desktop manifests

### DIFF
--- a/index/beekeeper-studio/5.5.7.toml
+++ b/index/beekeeper-studio/5.5.7.toml
@@ -1,0 +1,79 @@
+name = "beekeeper-studio"
+version = "5.5.7"
+license = "GPL-3.0-or-later"
+homepage = "https://www.beekeeperstudio.io"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v5.5.7/Beekeeper-Studio-5.5.7.AppImage"
+sha256 = "683a9deddb5f8bb765a9f940c8b2c5dfae64b2518c19013126f2d9aaf8461b40"
+
+[[artifacts.binaries]]
+name = "beekeeper-studio"
+path = "beekeeper-studio.AppImage"
+
+[[artifacts.gui_apps]]
+app_id = "io.beekeeperstudio.Studio"
+display_name = "Beekeeper Studio"
+exec = "beekeeper-studio.AppImage"
+categories = ["Development", "Database"]
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v5.5.7/Beekeeper-Studio-5.5.7-arm64.AppImage"
+sha256 = "47fd01ed7d53c818aaf061416d1f7eace8e1cf860c9b442338f06f48e37ef887"
+
+[[artifacts.binaries]]
+name = "beekeeper-studio"
+path = "beekeeper-studio-arm64.AppImage"
+
+[[artifacts.gui_apps]]
+app_id = "io.beekeeperstudio.Studio"
+display_name = "Beekeeper Studio"
+exec = "beekeeper-studio-arm64.AppImage"
+categories = ["Development", "Database"]
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v5.5.7/Beekeeper-Studio-5.5.7.dmg"
+sha256 = "2715053acb13019cd8c6b0361cdeb484c3f94687f4b6f519177dcc9e0d07da7a"
+
+[[artifacts.binaries]]
+name = "beekeeper-studio"
+path = "beekeeper-studio-mac.dmg"
+
+[[artifacts.gui_apps]]
+app_id = "io.beekeeperstudio.Studio"
+display_name = "Beekeeper Studio"
+exec = "Beekeeper Studio.app"
+categories = ["Development", "Database"]
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v5.5.7/Beekeeper-Studio-5.5.7-arm64.dmg"
+sha256 = "c4f56d3366adc0e439b2f33942f49b049c3d079393067ca7011dd1fe41da61b2"
+
+[[artifacts.binaries]]
+name = "beekeeper-studio"
+path = "beekeeper-studio-mac-arm64.dmg"
+
+[[artifacts.gui_apps]]
+app_id = "io.beekeeperstudio.Studio"
+display_name = "Beekeeper Studio"
+exec = "Beekeeper Studio.app"
+categories = ["Development", "Database"]
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v5.5.7/Beekeeper-Studio-5.5.7-portable.exe"
+sha256 = "71e67180fc631b58514863d69f3ab10ed59bc6ad0ddc08a09522d79a346ed429"
+
+[[artifacts.binaries]]
+name = "beekeeper-studio"
+path = "beekeeper-studio.exe"
+
+[[artifacts.gui_apps]]
+app_id = "io.beekeeperstudio.Studio"
+display_name = "Beekeeper Studio"
+exec = "beekeeper-studio.exe"
+categories = ["Development", "Database"]

--- a/index/bruno/3.1.4.toml
+++ b/index/bruno/3.1.4.toml
@@ -1,0 +1,100 @@
+name = "bruno"
+version = "3.1.4"
+license = "MIT"
+homepage = "https://github.com/usebruno/bruno"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/usebruno/bruno/releases/download/v3.1.4/bruno_3.1.4_x86_64_linux.AppImage"
+sha256 = "55a30be5a7902203109611e32fa14d0c4225d66121aaa08247da5ea1e8498f3e"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "bruno"
+path = "bruno"
+
+[[artifacts.gui_apps]]
+app_id = "com.usebruno.app"
+display_name = "Bruno"
+exec = "bruno"
+categories = ["Development"]
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/usebruno/bruno/releases/download/v3.1.4/bruno_3.1.4_arm64_linux.AppImage"
+sha256 = "a4788e7b28bd78bdf3572bf3c0b486f0ac72b6f89fc30716cf49ad736ae43e16"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "bruno"
+path = "bruno"
+
+[[artifacts.gui_apps]]
+app_id = "com.usebruno.app"
+display_name = "Bruno"
+exec = "bruno"
+categories = ["Development"]
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/usebruno/bruno/releases/download/v3.1.4/bruno_3.1.4_x64_mac.dmg"
+sha256 = "5afdc04491a0a3e33575595fc6fff02f92fe6733f35871d8b0e431f1f455becb"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "bruno"
+path = "Bruno.app/Contents/MacOS/Bruno"
+
+[[artifacts.gui_apps]]
+app_id = "com.usebruno.app"
+display_name = "Bruno"
+exec = "Bruno.app"
+categories = ["Development"]
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/usebruno/bruno/releases/download/v3.1.4/bruno_3.1.4_arm64_mac.dmg"
+sha256 = "99599391b6e1d24ef0e1915a5b6abcfe3f81ffe7119d522412e799a2c7655cd8"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "bruno"
+path = "Bruno.app/Contents/MacOS/Bruno"
+
+[[artifacts.gui_apps]]
+app_id = "com.usebruno.app"
+display_name = "Bruno"
+exec = "Bruno.app"
+categories = ["Development"]
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/usebruno/bruno/releases/download/v3.1.4/bruno_3.1.4_x64_win.exe"
+sha256 = "5c3aa4775573e79b9d7078892b4df67ae604258b561de914842dd29c13ca5104"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "bruno"
+path = "bruno.exe"
+
+[[artifacts.gui_apps]]
+app_id = "com.usebruno.app"
+display_name = "Bruno"
+exec = "bruno.exe"
+categories = ["Development"]
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+url = "https://github.com/usebruno/bruno/releases/download/v3.1.4/bruno_3.1.4_arm64_win.exe"
+sha256 = "c5a8b1c925c1641ee8e996b58eca0d1973e78ed733a0f0535dda24cc55c3fdff"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "bruno"
+path = "bruno.exe"
+
+[[artifacts.gui_apps]]
+app_id = "com.usebruno.app"
+display_name = "Bruno"
+exec = "bruno.exe"
+categories = ["Development"]

--- a/index/dbeaver/25.3.5.toml
+++ b/index/dbeaver/25.3.5.toml
@@ -1,0 +1,104 @@
+name = "dbeaver"
+version = "25.3.5"
+license = "Apache-2.0"
+homepage = "https://dbeaver.io/"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/dbeaver/dbeaver/releases/download/25.3.5/dbeaver-ce-25.3.5-linux-x86_64.tar.gz"
+sha256 = "a548cb336b4f215b86898a6fd1481f52720d3d1c7375b06f00f7de5f856cae7f"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "dbeaver"
+path = "dbeaver/dbeaver"
+
+[[artifacts.gui_apps]]
+app_id = "io.dbeaver.DBeaverCommunity"
+display_name = "DBeaver Community"
+exec = "dbeaver"
+categories = ["Development", "Database"]
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/dbeaver/dbeaver/releases/download/25.3.5/dbeaver-ce-25.3.5-linux-aarch64.tar.gz"
+sha256 = "dba459aeaa5c8873a09fa086261af1bf2821c5a203a23bf51a40bb0dff4ac320"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "dbeaver"
+path = "dbeaver/dbeaver"
+
+[[artifacts.gui_apps]]
+app_id = "io.dbeaver.DBeaverCommunity"
+display_name = "DBeaver Community"
+exec = "dbeaver"
+categories = ["Development", "Database"]
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/dbeaver/dbeaver/releases/download/25.3.5/dbeaver-ce-25.3.5-macos-x86_64.dmg"
+sha256 = "196ae8da178a527cbba6c3729b66c0f26f07be4f7a1a20d58580c6f708282628"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "dbeaver"
+path = "DBeaver.app/Contents/MacOS/dbeaver"
+
+[[artifacts.gui_apps]]
+app_id = "io.dbeaver.DBeaverCommunity"
+display_name = "DBeaver Community"
+exec = "DBeaver.app"
+categories = ["Development", "Database"]
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/dbeaver/dbeaver/releases/download/25.3.5/dbeaver-ce-25.3.5-macos-aarch64.dmg"
+sha256 = "2b682354729848bc0097426e699cb96432c45e9b261c72cf7d9524bae4d4a28e"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "dbeaver"
+path = "DBeaver.app/Contents/MacOS/dbeaver"
+
+[[artifacts.gui_apps]]
+app_id = "io.dbeaver.DBeaverCommunity"
+display_name = "DBeaver Community"
+exec = "DBeaver.app"
+categories = ["Development", "Database"]
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/dbeaver/dbeaver/releases/download/25.3.5/dbeaver-ce-25.3.5-windows-x86_64.zip"
+sha256 = "20b44004e28cd8e369d65fe8c28713a1c4c9f5e700d8cbe095a71f9035612f6f"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "dbeaver"
+path = "dbeaver/dbeaver.exe"
+
+[[artifacts.gui_apps]]
+app_id = "io.dbeaver.DBeaverCommunity"
+display_name = "DBeaver Community"
+exec = "dbeaver.exe"
+categories = ["Development", "Database"]
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+url = "https://github.com/dbeaver/dbeaver/releases/download/25.3.5/dbeaver-ce-25.3.5-windows-aarch64.zip"
+sha256 = "0ff731fd8d0639b3f4ca74d94af667f6dafba28ecd9cbb7dcf52024ea5eb0cf5"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "dbeaver"
+path = "dbeaver/dbeaver.exe"
+
+[[artifacts.gui_apps]]
+app_id = "io.dbeaver.DBeaverCommunity"
+display_name = "DBeaver Community"
+exec = "dbeaver.exe"
+categories = ["Development", "Database"]

--- a/index/insomnia/12.3.1.toml
+++ b/index/insomnia/12.3.1.toml
@@ -1,0 +1,68 @@
+name = "insomnia"
+version = "12.3.1"
+license = "Apache-2.0"
+homepage = "https://github.com/Kong/insomnia"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/Kong/insomnia/releases/download/core%4012.3.1/Insomnia.Core-12.3.1.AppImage"
+sha256 = "05c8dadf3fd029d27a34dbeb46348f3d4b2eab2e7726f780889f2362bc20dae6"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "insomnia"
+path = "insomnia"
+
+[[artifacts.gui_apps]]
+app_id = "com.insomnia.app"
+display_name = "Insomnia"
+exec = "insomnia"
+categories = ["Development"]
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/Kong/insomnia/releases/download/core%4012.3.1/Insomnia.Core-12.3.1.dmg"
+sha256 = "78a1d98d9f27551202dbc2c9968916a29d311c663261c512e9e873bb923ff021"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "insomnia"
+path = "Insomnia.app/Contents/MacOS/Insomnia"
+
+[[artifacts.gui_apps]]
+app_id = "com.insomnia.app"
+display_name = "Insomnia"
+exec = "Insomnia.app"
+categories = ["Development"]
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/Kong/insomnia/releases/download/core%4012.3.1/Insomnia.Core-12.3.1.dmg"
+sha256 = "78a1d98d9f27551202dbc2c9968916a29d311c663261c512e9e873bb923ff021"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "insomnia"
+path = "Insomnia.app/Contents/MacOS/Insomnia"
+
+[[artifacts.gui_apps]]
+app_id = "com.insomnia.app"
+display_name = "Insomnia"
+exec = "Insomnia.app"
+categories = ["Development"]
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/Kong/insomnia/releases/download/core%4012.3.1/Insomnia.Core-12.3.1.exe"
+sha256 = "e8b951c924a8f3c5eeb9caac8d578d4140db70ce994a49c565bcdb70930aff32"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "insomnia"
+path = "insomnia.exe"
+
+[[artifacts.gui_apps]]
+app_id = "com.insomnia.app"
+display_name = "Insomnia"
+exec = "insomnia.exe"
+categories = ["Development"]

--- a/index/redisinsight/3.2.0.toml
+++ b/index/redisinsight/3.2.0.toml
@@ -1,0 +1,68 @@
+name = "redisinsight"
+version = "3.2.0"
+license = "SSPL-1.0"
+homepage = "https://redis.io/insight/"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/redis/RedisInsight/releases/download/3.2.0/Redis-Insight-linux-x86_64.AppImage"
+sha256 = "6413db1e16d1cf0a291378a9ecc8495ddac06df39b8f30660d422d67eb8908fd"
+
+[[artifacts.binaries]]
+name = "redisinsight"
+path = "redisinsight"
+
+[[artifacts.gui_apps]]
+app_id = "org.RedisLabs.RedisInsight-V2"
+display_name = "Redis Insight"
+exec = "redisinsight"
+categories = ["Development", "Database"]
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/redis/RedisInsight/releases/download/3.2.0/Redis-Insight-mac-arm64.zip"
+sha256 = "c91ba226e5f3e049f477750933e9324b4836d90326d8b731d3fea44307833806"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "redisinsight"
+path = "Redis Insight.app/Contents/MacOS/Redis Insight"
+
+[[artifacts.gui_apps]]
+app_id = "org.RedisLabs.RedisInsight-V2"
+display_name = "Redis Insight"
+exec = "Redis Insight.app"
+categories = ["Development", "Database"]
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/redis/RedisInsight/releases/download/3.2.0/Redis-Insight-mac-x64.zip"
+sha256 = "019ad91a367f5ddaa8b14d04c075e449d2b6de047ee37a7035de395e4c49da32"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "redisinsight"
+path = "Redis Insight.app/Contents/MacOS/Redis Insight"
+
+[[artifacts.gui_apps]]
+app_id = "org.RedisLabs.RedisInsight-V2"
+display_name = "Redis Insight"
+exec = "Redis Insight.app"
+categories = ["Development", "Database"]
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/redis/RedisInsight/releases/download/3.2.0/Redis-Insight-win-installer.exe"
+sha256 = "56c711522f1acb7d05576a9884786d931d067590f48ad80701d846fb60d2a94a"
+
+[[artifacts.binaries]]
+name = "redisinsight"
+path = "redisinsight.exe"
+
+[[artifacts.gui_apps]]
+app_id = "org.RedisLabs.RedisInsight-V2"
+display_name = "Redis Insight"
+exec = "redisinsight.exe"
+categories = ["Development", "Database"]


### PR DESCRIPTION
## Summary
- Add new registry manifests for `bruno@3.1.4`, `insomnia@12.3.1`, `dbeaver@25.3.5`, `beekeeper-studio@5.5.7`, and `redisinsight@3.2.0`
- Include `[[artifacts.gui_apps]]` metadata and per-target binaries for Linux/macOS/Windows with arm variants where upstream publishes them
- Use immutable upstream release URLs and pinned SHA-256 values for each artifact

## Test Plan
- [x] `python3 scripts/registry-validate-entry.py index/bruno/3.1.4.toml`
- [x] `python3 scripts/registry-validate-entry.py index/insomnia/12.3.1.toml`
- [x] `python3 scripts/registry-validate-entry.py index/dbeaver/25.3.5.toml`
- [x] `python3 scripts/registry-validate-entry.py index/beekeeper-studio/5.5.7.toml`
- [x] `python3 scripts/registry-validate-entry.py index/redisinsight/3.2.0.toml`
- [x] `python3 scripts/registry-validate.py --allow-missing-signatures index/bruno/3.1.4.toml index/insomnia/12.3.1.toml index/dbeaver/25.3.5.toml index/beekeeper-studio/5.5.7.toml index/redisinsight/3.2.0.toml`
- [x] `python3 scripts/registry-smoke-install.py --require-runner-target index/bruno/3.1.4.toml`
- [x] `python3 scripts/registry-smoke-install.py --require-runner-target index/insomnia/12.3.1.toml`
- [x] `python3 scripts/registry-smoke-install.py --require-runner-target index/dbeaver/25.3.5.toml`
- [x] `python3 scripts/registry-smoke-install.py --require-runner-target index/beekeeper-studio/5.5.7.toml`
- [x] `python3 scripts/registry-smoke-install.py --require-runner-target index/redisinsight/3.2.0.toml`