### PR TITLE
chore(registry): automate manifest updates from upstream releases

### DIFF
--- a/.github/workflows/upstream-release-bot.yml
+++ b/.github/workflows/upstream-release-bot.yml
@@ -1,0 +1,67 @@
+name: Upstream Release Bot
+
+on:
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run without writing manifests or opening PRs'
+        required: false
+        default: false
+        type: boolean
+      package:
+        description: 'Optional package filter'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: upstream-release-bot
+  cancel-in-progress: false
+
+jobs:
+  update-registry-manifests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Validate source configuration
+        run: python3 scripts/registry-validate-source.py registry/sources/*.toml
+
+      - name: Run release bot (dry run)
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PACKAGE_INPUT: ${{ inputs.package }}
+        run: |
+          set -euo pipefail
+          args=(--dry-run)
+          if [ -n "$PACKAGE_INPUT" ]; then
+            args+=(--package "$PACKAGE_INPUT")
+          fi
+          python3 scripts/upstream-release-bot.py "${args[@]}"
+
+      - name: Run release bot (create PRs)
+        if: github.event_name != 'workflow_dispatch' || !inputs.dry_run
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PACKAGE_INPUT: ${{ inputs.package }}
+        run: |
+          set -euo pipefail
+          args=(--create-prs)
+          if [ -n "$PACKAGE_INPUT" ]; then
+            args+=(--package "$PACKAGE_INPUT")
+          fi
+          python3 scripts/upstream-release-bot.py "${args[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .secrets/
 logs/*.log
 artifacts/
+**/__pycache__/

--- a/README.md
+++ b/README.md
@@ -53,6 +53,33 @@ If a published package update must be rolled back:
 - Configure repository secret `CROSSPACK_REGISTRY_SIGNING_PRIVATE_KEY_PEM` (Ed25519 private key PEM).
 - Ensure workflow permissions allow `contents: write` so generated `.sig` files can be committed back to `main`.
 
+## Upstream Release Bot
+
+Manifest updates no longer need to be hand-authored for configured packages.
+
+- Source-of-truth config lives in `registry/sources/*.toml`.
+- Workflow `.github/workflows/upstream-release-bot.yml` checks upstream releases on a schedule and opens PRs for new versions.
+- Generated manifests still flow through `.github/workflows/registry-quality-gate.yml` and are signed after merge by `.github/workflows/sign-manifests-on-merge.yml`.
+
+Useful commands:
+
+```bash
+# Validate source configs
+python3 scripts/registry-validate-source.py registry/sources/*.toml
+
+# Dry-run release detection and generation planning
+python3 scripts/upstream-release-bot.py --dry-run
+
+# Limit to a single package
+python3 scripts/upstream-release-bot.py --dry-run --package ripgrep
+```
+
+Emergency/manual override remains available:
+
+- Use `scripts/registry-scaffold-entry.sh` for one-off hotfix manifests.
+- Open a normal PR with `index/<package>/<version>.toml` changes.
+- Allow post-merge signature automation to generate/update `.sig` sidecars.
+
 ## Registry Preflight (Local + CI)
 
 CI enforces a registry quality gate that validates changed manifests and runs smoke-install checks.

--- a/registry/sources/bat.toml
+++ b/registry/sources/bat.toml
@@ -1,0 +1,59 @@
+name = "bat"
+license = "Apache-2.0 OR MIT"
+homepage = "https://github.com/sharkdp/bat"
+
+[source]
+provider = "github"
+repo = "sharkdp/bat"
+tag_prefix = "v"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "bat-v{version}-x86_64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "bat"
+path = "bat"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "bat-v{version}-aarch64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "bat"
+path = "bat"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "bat-v{version}-x86_64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "bat"
+path = "bat"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "bat-v{version}-aarch64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "bat"
+path = "bat"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "bat-v{version}-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "bat"
+path = "bat.exe"

--- a/registry/sources/beekeeper-studio.toml
+++ b/registry/sources/beekeeper-studio.toml
@@ -1,0 +1,79 @@
+name = "beekeeper-studio"
+license = "GPL-3.0-or-later"
+homepage = "https://www.beekeeperstudio.io"
+
+[source]
+provider = "github"
+repo = "beekeeper-studio/beekeeper-studio"
+tag_prefix = "v"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "Beekeeper-Studio-{version}.AppImage"
+
+[[artifacts.binaries]]
+name = "beekeeper-studio"
+path = "beekeeper-studio.AppImage"
+
+[[artifacts.gui_apps]]
+app_id = "io.beekeeperstudio.Studio"
+display_name = "Beekeeper Studio"
+exec = "beekeeper-studio.AppImage"
+categories = ["Development", "Database"]
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "Beekeeper-Studio-{version}-arm64.AppImage"
+
+[[artifacts.binaries]]
+name = "beekeeper-studio"
+path = "beekeeper-studio-arm64.AppImage"
+
+[[artifacts.gui_apps]]
+app_id = "io.beekeeperstudio.Studio"
+display_name = "Beekeeper Studio"
+exec = "beekeeper-studio-arm64.AppImage"
+categories = ["Development", "Database"]
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "Beekeeper-Studio-{version}.dmg"
+
+[[artifacts.binaries]]
+name = "beekeeper-studio"
+path = "beekeeper-studio-mac.dmg"
+
+[[artifacts.gui_apps]]
+app_id = "io.beekeeperstudio.Studio"
+display_name = "Beekeeper Studio"
+exec = "Beekeeper Studio.app"
+categories = ["Development", "Database"]
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "Beekeeper-Studio-{version}-arm64.dmg"
+
+[[artifacts.binaries]]
+name = "beekeeper-studio"
+path = "beekeeper-studio-mac-arm64.dmg"
+
+[[artifacts.gui_apps]]
+app_id = "io.beekeeperstudio.Studio"
+display_name = "Beekeeper Studio"
+exec = "Beekeeper Studio.app"
+categories = ["Development", "Database"]
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "Beekeeper-Studio-{version}-portable.exe"
+
+[[artifacts.binaries]]
+name = "beekeeper-studio"
+path = "beekeeper-studio.exe"
+
+[[artifacts.gui_apps]]
+app_id = "io.beekeeperstudio.Studio"
+display_name = "Beekeeper Studio"
+exec = "beekeeper-studio.exe"
+categories = ["Development", "Database"]

--- a/registry/sources/bruno.toml
+++ b/registry/sources/bruno.toml
@@ -1,0 +1,99 @@
+name = "bruno"
+license = "MIT"
+homepage = "https://github.com/usebruno/bruno"
+
+[source]
+provider = "github"
+repo = "usebruno/bruno"
+tag_prefix = "v"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "bruno_{version}_x86_64_linux.AppImage"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "bruno"
+path = "bruno"
+
+[[artifacts.gui_apps]]
+app_id = "com.usebruno.app"
+display_name = "Bruno"
+exec = "bruno"
+categories = ["Development"]
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "bruno_{version}_arm64_linux.AppImage"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "bruno"
+path = "bruno"
+
+[[artifacts.gui_apps]]
+app_id = "com.usebruno.app"
+display_name = "Bruno"
+exec = "bruno"
+categories = ["Development"]
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "bruno_{version}_x64_mac.dmg"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "bruno"
+path = "Bruno.app/Contents/MacOS/Bruno"
+
+[[artifacts.gui_apps]]
+app_id = "com.usebruno.app"
+display_name = "Bruno"
+exec = "Bruno.app"
+categories = ["Development"]
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "bruno_{version}_arm64_mac.dmg"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "bruno"
+path = "Bruno.app/Contents/MacOS/Bruno"
+
+[[artifacts.gui_apps]]
+app_id = "com.usebruno.app"
+display_name = "Bruno"
+exec = "Bruno.app"
+categories = ["Development"]
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "bruno_{version}_x64_win.exe"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "bruno"
+path = "bruno.exe"
+
+[[artifacts.gui_apps]]
+app_id = "com.usebruno.app"
+display_name = "Bruno"
+exec = "bruno.exe"
+categories = ["Development"]
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "bruno_{version}_arm64_win.exe"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "bruno"
+path = "bruno.exe"
+
+[[artifacts.gui_apps]]
+app_id = "com.usebruno.app"
+display_name = "Bruno"
+exec = "bruno.exe"
+categories = ["Development"]

--- a/registry/sources/crosspack.toml
+++ b/registry/sources/crosspack.toml
@@ -1,0 +1,83 @@
+name = "crosspack"
+license = "MIT"
+homepage = "https://github.com/spiritledsoftware/crosspack"
+
+[source]
+provider = "github"
+repo = "spiritledsoftware/crosspack"
+tag_prefix = "v"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "crosspack-v{version}-x86_64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "crosspack"
+path = "crosspack"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "crosspack-v{version}-aarch64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "crosspack"
+path = "crosspack"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-musl"
+asset = "crosspack-v{version}-x86_64-unknown-linux-musl.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "crosspack"
+path = "crosspack"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-musl"
+asset = "crosspack-v{version}-aarch64-unknown-linux-musl.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "crosspack"
+path = "crosspack"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "crosspack-v{version}-x86_64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "crosspack"
+path = "crosspack"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "crosspack-v{version}-aarch64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "crosspack"
+path = "crosspack"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "crosspack-v{version}-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "crosspack"
+path = "crosspack.exe"
+
+[[artifacts.binaries]]
+name = "cpk"
+path = "crosspack.exe"

--- a/registry/sources/dbeaver.toml
+++ b/registry/sources/dbeaver.toml
@@ -1,0 +1,102 @@
+name = "dbeaver"
+license = "Apache-2.0"
+homepage = "https://dbeaver.io/"
+
+[source]
+provider = "github"
+repo = "dbeaver/dbeaver"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "dbeaver-ce-{version}-linux-x86_64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "dbeaver"
+path = "dbeaver/dbeaver"
+
+[[artifacts.gui_apps]]
+app_id = "io.dbeaver.DBeaverCommunity"
+display_name = "DBeaver Community"
+exec = "dbeaver"
+categories = ["Development", "Database"]
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "dbeaver-ce-{version}-linux-aarch64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "dbeaver"
+path = "dbeaver/dbeaver"
+
+[[artifacts.gui_apps]]
+app_id = "io.dbeaver.DBeaverCommunity"
+display_name = "DBeaver Community"
+exec = "dbeaver"
+categories = ["Development", "Database"]
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "dbeaver-ce-{version}-macos-x86_64.dmg"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "dbeaver"
+path = "DBeaver.app/Contents/MacOS/dbeaver"
+
+[[artifacts.gui_apps]]
+app_id = "io.dbeaver.DBeaverCommunity"
+display_name = "DBeaver Community"
+exec = "DBeaver.app"
+categories = ["Development", "Database"]
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "dbeaver-ce-{version}-macos-aarch64.dmg"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "dbeaver"
+path = "DBeaver.app/Contents/MacOS/dbeaver"
+
+[[artifacts.gui_apps]]
+app_id = "io.dbeaver.DBeaverCommunity"
+display_name = "DBeaver Community"
+exec = "DBeaver.app"
+categories = ["Development", "Database"]
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "dbeaver-ce-{version}-windows-x86_64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "dbeaver"
+path = "dbeaver/dbeaver.exe"
+
+[[artifacts.gui_apps]]
+app_id = "io.dbeaver.DBeaverCommunity"
+display_name = "DBeaver Community"
+exec = "dbeaver.exe"
+categories = ["Development", "Database"]
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "dbeaver-ce-{version}-windows-aarch64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "dbeaver"
+path = "dbeaver/dbeaver.exe"
+
+[[artifacts.gui_apps]]
+app_id = "io.dbeaver.DBeaverCommunity"
+display_name = "DBeaver Community"
+exec = "dbeaver.exe"
+categories = ["Development", "Database"]

--- a/registry/sources/delta.toml
+++ b/registry/sources/delta.toml
@@ -1,0 +1,58 @@
+name = "delta"
+license = "MIT"
+homepage = "https://github.com/dandavison/delta"
+
+[source]
+provider = "github"
+repo = "dandavison/delta"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "delta-{version}-x86_64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "delta"
+path = "delta"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "delta-{version}-aarch64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "delta"
+path = "delta"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "delta-{version}-x86_64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "delta"
+path = "delta"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "delta-{version}-aarch64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "delta"
+path = "delta"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "delta-{version}-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "delta"
+path = "delta.exe"

--- a/registry/sources/fd.toml
+++ b/registry/sources/fd.toml
@@ -1,0 +1,165 @@
+name = "fd"
+license = "Apache-2.0 OR MIT"
+homepage = "https://github.com/sharkdp/fd"
+
+[source]
+provider = "github"
+repo = "sharkdp/fd"
+tag_prefix = "v"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "fd-v{version}-x86_64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "fd"
+path = "fd"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "autocomplete/fd.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "autocomplete/_fd"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "autocomplete/fd.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "autocomplete/fd.ps1"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "fd-v{version}-aarch64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "fd"
+path = "fd"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "autocomplete/fd.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "autocomplete/_fd"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "autocomplete/fd.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "autocomplete/fd.ps1"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "fd-v{version}-x86_64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "fd"
+path = "fd"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "autocomplete/fd.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "autocomplete/_fd"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "autocomplete/fd.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "autocomplete/fd.ps1"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "fd-v{version}-aarch64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "fd"
+path = "fd"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "autocomplete/fd.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "autocomplete/_fd"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "autocomplete/fd.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "autocomplete/fd.ps1"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "fd-v{version}-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "fd"
+path = "fd.exe"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "autocomplete/fd.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "autocomplete/_fd"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "autocomplete/fd.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "autocomplete/fd.ps1"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "fd-v{version}-aarch64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "fd"
+path = "fd.exe"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "autocomplete/fd.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "autocomplete/_fd"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "autocomplete/fd.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "autocomplete/fd.ps1"

--- a/registry/sources/fzf.toml
+++ b/registry/sources/fzf.toml
@@ -1,0 +1,69 @@
+name = "fzf"
+license = "MIT"
+homepage = "https://github.com/junegunn/fzf"
+
+[source]
+provider = "github"
+repo = "junegunn/fzf"
+tag_prefix = "v"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "fzf-{version}-linux_amd64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "fzf"
+path = "fzf"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "fzf-{version}-linux_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "fzf"
+path = "fzf"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "fzf-{version}-darwin_amd64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "fzf"
+path = "fzf"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "fzf-{version}-darwin_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "fzf"
+path = "fzf"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "fzf-{version}-windows_amd64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "fzf"
+path = "fzf.exe"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "fzf-{version}-windows_arm64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "fzf"
+path = "fzf.exe"

--- a/registry/sources/gh.toml
+++ b/registry/sources/gh.toml
@@ -1,0 +1,59 @@
+name = "gh"
+license = "MIT"
+homepage = "https://github.com/cli/cli"
+
+[source]
+provider = "github"
+repo = "cli/cli"
+tag_prefix = "v"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "gh_{version}_linux_amd64.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "gh"
+path = "bin/gh"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "gh_{version}_linux_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "gh"
+path = "bin/gh"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "gh_{version}_macOS_amd64.zip"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "gh"
+path = "bin/gh"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "gh_{version}_macOS_arm64.zip"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "gh"
+path = "bin/gh"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "gh_{version}_windows_amd64.zip"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "gh"
+path = "bin/gh.exe"

--- a/registry/sources/insomnia.toml
+++ b/registry/sources/insomnia.toml
@@ -1,0 +1,69 @@
+name = "insomnia"
+license = "Apache-2.0"
+homepage = "https://github.com/Kong/insomnia"
+
+[source]
+provider = "github"
+repo = "Kong/insomnia"
+tag_prefix = "core@"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "Insomnia.Core-{version}.AppImage"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "insomnia"
+path = "insomnia"
+
+[[artifacts.gui_apps]]
+app_id = "com.insomnia.app"
+display_name = "Insomnia"
+exec = "insomnia"
+categories = ["Development"]
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "Insomnia.Core-{version}.dmg"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "insomnia"
+path = "Insomnia.app/Contents/MacOS/Insomnia"
+
+[[artifacts.gui_apps]]
+app_id = "com.insomnia.app"
+display_name = "Insomnia"
+exec = "Insomnia.app"
+categories = ["Development"]
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "Insomnia.Core-{version}.dmg"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "insomnia"
+path = "Insomnia.app/Contents/MacOS/Insomnia"
+
+[[artifacts.gui_apps]]
+app_id = "com.insomnia.app"
+display_name = "Insomnia"
+exec = "Insomnia.app"
+categories = ["Development"]
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "Insomnia.Core-{version}.exe"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "insomnia"
+path = "insomnia.exe"
+
+[[artifacts.gui_apps]]
+app_id = "com.insomnia.app"
+display_name = "Insomnia"
+exec = "insomnia.exe"
+categories = ["Development"]

--- a/registry/sources/jq.toml
+++ b/registry/sources/jq.toml
@@ -1,0 +1,52 @@
+name = "jq"
+license = "MIT"
+homepage = "https://github.com/jqlang/jq"
+
+[source]
+provider = "github"
+repo = "jqlang/jq"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "jq-linux-amd64"
+archive = "bin"
+
+[[artifacts.binaries]]
+name = "jq"
+path = "jq-linux-amd64"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "jq-linux-arm64"
+archive = "bin"
+
+[[artifacts.binaries]]
+name = "jq"
+path = "jq-linux-arm64"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "jq-macos-amd64"
+archive = "bin"
+
+[[artifacts.binaries]]
+name = "jq"
+path = "jq-macos-amd64"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "jq-macos-arm64"
+archive = "bin"
+
+[[artifacts.binaries]]
+name = "jq"
+path = "jq-macos-arm64"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "jq-windows-amd64.exe"
+
+[[artifacts.binaries]]
+name = "jq"
+path = "jq-windows-amd64.exe"

--- a/registry/sources/lazygit.toml
+++ b/registry/sources/lazygit.toml
@@ -1,0 +1,59 @@
+name = "lazygit"
+license = "MIT"
+homepage = "https://github.com/jesseduffield/lazygit"
+
+[source]
+provider = "github"
+repo = "jesseduffield/lazygit"
+tag_prefix = "v"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "lazygit_{version}_linux_x86_64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "lazygit"
+path = "lazygit"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "lazygit_{version}_linux_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "lazygit"
+path = "lazygit"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "lazygit_{version}_darwin_x86_64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "lazygit"
+path = "lazygit"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "lazygit_{version}_darwin_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "lazygit"
+path = "lazygit"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "lazygit_{version}_windows_x86_64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "lazygit"
+path = "lazygit.exe"

--- a/registry/sources/neovide.toml
+++ b/registry/sources/neovide.toml
@@ -1,0 +1,70 @@
+name = "neovide"
+license = "MIT"
+homepage = "https://github.com/neovide/neovide"
+
+[source]
+provider = "github"
+repo = "neovide/neovide"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "neovide-linux-x86_64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "neovide"
+path = "neovide"
+
+[[artifacts.gui_apps]]
+app_id = "io.neovide.neovide"
+display_name = "Neovide"
+exec = "neovide"
+categories = ["Utility", "Development"]
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "Neovide-aarch64-apple-darwin.dmg"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "neovide"
+path = "Neovide.app/Contents/MacOS/neovide"
+
+[[artifacts.gui_apps]]
+app_id = "io.neovide.neovide"
+display_name = "Neovide"
+exec = "Neovide.app"
+categories = ["Utility", "Development"]
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "Neovide-x86_64-apple-darwin.dmg"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "neovide"
+path = "Neovide.app/Contents/MacOS/neovide"
+
+[[artifacts.gui_apps]]
+app_id = "io.neovide.neovide"
+display_name = "Neovide"
+exec = "Neovide.app"
+categories = ["Utility", "Development"]
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "neovide.exe.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "neovide"
+path = "neovide.exe"
+
+[[artifacts.gui_apps]]
+app_id = "io.neovide.neovide"
+display_name = "Neovide"
+exec = "neovide.exe"
+categories = ["Utility", "Development"]

--- a/registry/sources/redisinsight.toml
+++ b/registry/sources/redisinsight.toml
@@ -1,0 +1,68 @@
+name = "redisinsight"
+license = "SSPL-1.0"
+homepage = "https://redis.io/insight/"
+
+[source]
+provider = "github"
+repo = "redis/RedisInsight"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "Redis-Insight-linux-x86_64.AppImage"
+
+[[artifacts.binaries]]
+name = "redisinsight"
+path = "redisinsight"
+
+[[artifacts.gui_apps]]
+app_id = "org.RedisLabs.RedisInsight-V2"
+display_name = "Redis Insight"
+exec = "redisinsight"
+categories = ["Development", "Database"]
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "Redis-Insight-mac-arm64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "redisinsight"
+path = "Redis Insight.app/Contents/MacOS/Redis Insight"
+
+[[artifacts.gui_apps]]
+app_id = "org.RedisLabs.RedisInsight-V2"
+display_name = "Redis Insight"
+exec = "Redis Insight.app"
+categories = ["Development", "Database"]
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "Redis-Insight-mac-x64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "redisinsight"
+path = "Redis Insight.app/Contents/MacOS/Redis Insight"
+
+[[artifacts.gui_apps]]
+app_id = "org.RedisLabs.RedisInsight-V2"
+display_name = "Redis Insight"
+exec = "Redis Insight.app"
+categories = ["Development", "Database"]
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "Redis-Insight-win-installer.exe"
+
+[[artifacts.binaries]]
+name = "redisinsight"
+path = "redisinsight.exe"
+
+[[artifacts.gui_apps]]
+app_id = "org.RedisLabs.RedisInsight-V2"
+display_name = "Redis Insight"
+exec = "redisinsight.exe"
+categories = ["Development", "Database"]

--- a/registry/sources/ripgrep.toml
+++ b/registry/sources/ripgrep.toml
@@ -1,0 +1,164 @@
+name = "ripgrep"
+license = "MIT OR Unlicense"
+homepage = "https://github.com/BurntSushi/ripgrep"
+
+[source]
+provider = "github"
+repo = "BurntSushi/ripgrep"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "ripgrep-{version}-x86_64-unknown-linux-musl.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "rg"
+path = "rg"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "complete/rg.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "complete/_rg"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "complete/rg.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "complete/_rg.ps1"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "ripgrep-{version}-aarch64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "rg"
+path = "rg"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "complete/rg.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "complete/_rg"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "complete/rg.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "complete/_rg.ps1"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "ripgrep-{version}-x86_64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "rg"
+path = "rg"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "complete/rg.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "complete/_rg"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "complete/rg.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "complete/_rg.ps1"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "ripgrep-{version}-aarch64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "rg"
+path = "rg"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "complete/rg.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "complete/_rg"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "complete/rg.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "complete/_rg.ps1"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "ripgrep-{version}-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "rg"
+path = "rg.exe"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "complete/rg.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "complete/_rg"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "complete/rg.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "complete/_rg.ps1"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "ripgrep-{version}-aarch64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "rg"
+path = "rg.exe"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "complete/rg.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "complete/_rg"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "complete/rg.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "complete/_rg.ps1"

--- a/registry/sources/starship.toml
+++ b/registry/sources/starship.toml
@@ -1,0 +1,59 @@
+name = "starship"
+license = "ISC"
+homepage = "https://github.com/starship/starship"
+
+[source]
+provider = "github"
+repo = "starship/starship"
+tag_prefix = "v"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "starship-x86_64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "starship"
+path = "starship"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-musl"
+asset = "starship-aarch64-unknown-linux-musl.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "starship"
+path = "starship"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "starship-x86_64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "starship"
+path = "starship"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "starship-aarch64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "starship"
+path = "starship"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "starship-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "starship"
+path = "starship.exe"

--- a/registry/sources/uv.toml
+++ b/registry/sources/uv.toml
@@ -1,0 +1,78 @@
+name = "uv"
+license = "MIT OR Apache-2.0"
+homepage = "https://github.com/astral-sh/uv"
+
+[source]
+provider = "github"
+repo = "astral-sh/uv"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "uv-x86_64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "uv"
+path = "uv"
+
+[[artifacts.binaries]]
+name = "uvx"
+path = "uvx"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "uv-aarch64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "uv"
+path = "uv"
+
+[[artifacts.binaries]]
+name = "uvx"
+path = "uvx"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "uv-x86_64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "uv"
+path = "uv"
+
+[[artifacts.binaries]]
+name = "uvx"
+path = "uvx"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "uv-aarch64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "uv"
+path = "uv"
+
+[[artifacts.binaries]]
+name = "uvx"
+path = "uvx"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "uv-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "uv"
+path = "uv.exe"
+
+[[artifacts.binaries]]
+name = "uvx"
+path = "uvx.exe"

--- a/scripts/registry-generate-manifest.py
+++ b/scripts/registry-generate-manifest.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import tempfile
+import urllib.request
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+class GenerateError(Exception):
+    pass
+
+
+def _escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _line(key: str, value: object) -> str:
+    if isinstance(value, str):
+        return f'{key} = "{_escape(value)}"'
+    if isinstance(value, bool):
+        return f"{key} = {'true' if value else 'false'}"
+    if isinstance(value, int):
+        return f"{key} = {value}"
+    if isinstance(value, list):
+        str_values = ", ".join(f'"{_escape(str(v))}"' for v in value)
+        return f"{key} = [{str_values}]"
+    raise GenerateError(f"unsupported TOML value type for {key}")
+
+
+def render_manifest(doc: dict) -> str:
+    chunks: list[str] = []
+    chunks.append(_line("name", doc["name"]))
+    chunks.append(_line("version", doc["version"]))
+    chunks.append(_line("license", doc["license"]))
+    chunks.append(_line("homepage", doc["homepage"]))
+    chunks.append("")
+
+    for artifact in doc["artifacts"]:
+        chunks.append("[[artifacts]]")
+        chunks.append(_line("target", artifact["target"]))
+        chunks.append(_line("url", artifact["url"]))
+        chunks.append(_line("sha256", artifact["sha256"]))
+        if "archive" in artifact:
+            chunks.append(_line("archive", artifact["archive"]))
+        if "strip_components" in artifact:
+            chunks.append(_line("strip_components", artifact["strip_components"]))
+        chunks.append("")
+
+        for binary in artifact["binaries"]:
+            chunks.append("[[artifacts.binaries]]")
+            chunks.append(_line("name", binary["name"]))
+            chunks.append(_line("path", binary["path"]))
+        if artifact["binaries"]:
+            chunks.append("")
+
+        for completion in artifact.get("completions", []):
+            chunks.append("[[artifacts.completions]]")
+            chunks.append(_line("shell", completion["shell"]))
+            chunks.append(_line("path", completion["path"]))
+            chunks.append("")
+
+        for gui_app in artifact.get("gui_apps", []):
+            chunks.append("[[artifacts.gui_apps]]")
+            chunks.append(_line("app_id", gui_app["app_id"]))
+            chunks.append(_line("display_name", gui_app["display_name"]))
+            chunks.append(_line("exec", gui_app["exec"]))
+            chunks.append(_line("categories", gui_app["categories"]))
+            chunks.append("")
+
+    return "\n".join(chunks).rstrip() + "\n"
+
+
+def download(url: str, dest: Path) -> None:
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/octet-stream",
+            "User-Agent": "crosspack-registry-upstream-bot",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as response:  # noqa: S310
+        dest.write_bytes(response.read())
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            block = handle.read(1024 * 1024)
+            if not block:
+                break
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _asset_map(release: dict) -> dict[str, dict]:
+    assets = release.get("assets", [])
+    if not isinstance(assets, list):
+        raise GenerateError("release.assets must be a list")
+    out: dict[str, dict] = {}
+    for asset in assets:
+        if not isinstance(asset, dict):
+            continue
+        name = asset.get("name")
+        if isinstance(name, str):
+            out[name] = asset
+    return out
+
+
+def generate_manifest_text(
+    *,
+    config_path: Path,
+    version: str,
+    release: dict,
+    downloader=download,
+) -> str:
+    config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    if not isinstance(config, dict):
+        raise GenerateError("source config root must be a table")
+
+    assets = _asset_map(release)
+    manifest_artifacts: list[dict] = []
+
+    for artifact in config.get("artifacts", []):
+        target = artifact["target"]
+        asset_name = artifact["asset"].format(version=version)
+        release_asset = assets.get(asset_name)
+        if release_asset is None:
+            raise GenerateError(
+                f"missing release asset '{asset_name}' for target '{target}'"
+            )
+
+        url = release_asset.get("browser_download_url")
+        if not isinstance(url, str) or not url.startswith("https://"):
+            raise GenerateError(f"invalid download URL for asset '{asset_name}'")
+
+        with tempfile.TemporaryDirectory(prefix="manifest-gen-") as tmp:
+            artifact_path = Path(tmp) / asset_name
+            downloader(url, artifact_path)
+            checksum = sha256_file(artifact_path)
+
+        entry = {
+            "target": target,
+            "url": url,
+            "sha256": checksum,
+            "binaries": artifact["binaries"],
+        }
+        if "archive" in artifact:
+            entry["archive"] = artifact["archive"]
+        if "strip_components" in artifact:
+            entry["strip_components"] = artifact["strip_components"]
+        if "completions" in artifact:
+            entry["completions"] = artifact["completions"]
+        if "gui_apps" in artifact:
+            entry["gui_apps"] = artifact["gui_apps"]
+        manifest_artifacts.append(entry)
+
+    document = {
+        "name": config["name"],
+        "version": version,
+        "license": config["license"],
+        "homepage": config["homepage"],
+        "artifacts": manifest_artifacts,
+    }
+    return render_manifest(document)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate registry manifest from source config"
+    )
+    parser.add_argument(
+        "--config", required=True, type=Path, help="registry/sources/<pkg>.toml"
+    )
+    parser.add_argument("--version", required=True, help="Release version (semver)")
+    parser.add_argument(
+        "--release-json", required=True, type=Path, help="Path to release JSON"
+    )
+    parser.add_argument(
+        "--output", required=True, type=Path, help="Output manifest path"
+    )
+    args = parser.parse_args(argv)
+
+    release = json.loads(args.release_json.read_text(encoding="utf-8"))
+    text = generate_manifest_text(
+        config_path=args.config,
+        version=args.version,
+        release=release,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(text, encoding="utf-8")
+    print(f"Generated {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(__import__("sys").argv[1:]))

--- a/scripts/registry-validate-source.py
+++ b/scripts/registry-validate-source.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+class ValidationError(Exception):
+    pass
+
+
+ARCHIVE_VALUES = {"tar.gz", "zip", "tar.xz", "tgz", "bin"}
+TARGET_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+REPO_RE = re.compile(r"^[^/\s]+/[^/\s]+$")
+
+
+def _expect_non_empty_str(obj: dict, key: str, ctx: str) -> str:
+    value = obj.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{ctx}.{key} must be a non-empty string")
+    return value
+
+
+def _expect_optional_non_negative_int(obj: dict, key: str, ctx: str) -> None:
+    if key not in obj:
+        return
+    value = obj[key]
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValidationError(f"{ctx}.{key} must be an integer >= 0")
+
+
+def validate_source_config(doc: dict) -> None:
+    _expect_non_empty_str(doc, "name", "manifest")
+    _expect_non_empty_str(doc, "license", "manifest")
+    homepage = _expect_non_empty_str(doc, "homepage", "manifest")
+    if not homepage.startswith("https://"):
+        raise ValidationError("manifest.homepage must start with https://")
+
+    source = doc.get("source")
+    if not isinstance(source, dict):
+        raise ValidationError("manifest.source must be a table")
+
+    provider = _expect_non_empty_str(source, "provider", "manifest.source")
+    if provider != "github":
+        raise ValidationError("manifest.source.provider must be 'github'")
+
+    repo = _expect_non_empty_str(source, "repo", "manifest.source")
+    if not REPO_RE.fullmatch(repo):
+        raise ValidationError("manifest.source.repo must look like owner/name")
+
+    include_prereleases = source.get("include_prereleases")
+    if include_prereleases is not None and not isinstance(include_prereleases, bool):
+        raise ValidationError("manifest.source.include_prereleases must be a boolean")
+
+    tag_prefix = source.get("tag_prefix")
+    if tag_prefix is not None and not isinstance(tag_prefix, str):
+        raise ValidationError("manifest.source.tag_prefix must be a string")
+
+    artifacts = doc.get("artifacts")
+    if not isinstance(artifacts, list) or not artifacts:
+        raise ValidationError("manifest.artifacts must be a non-empty array")
+
+    for idx, artifact in enumerate(artifacts):
+        if not isinstance(artifact, dict):
+            raise ValidationError(f"manifest.artifacts[{idx}] must be a table")
+
+        prefix = f"manifest.artifacts[{idx}]"
+        target = _expect_non_empty_str(artifact, "target", prefix)
+        if not TARGET_RE.fullmatch(target):
+            raise ValidationError(f"{prefix}.target has invalid characters")
+
+        _expect_non_empty_str(artifact, "asset", prefix)
+
+        archive = artifact.get("archive")
+        if archive is not None and archive not in ARCHIVE_VALUES:
+            raise ValidationError(
+                f"{prefix}.archive must be one of {', '.join(sorted(ARCHIVE_VALUES))}"
+            )
+
+        _expect_optional_non_negative_int(artifact, "strip_components", prefix)
+
+        binaries = artifact.get("binaries")
+        if not isinstance(binaries, list) or not binaries:
+            raise ValidationError(f"{prefix}.binaries must be a non-empty array")
+
+        for bidx, binary in enumerate(binaries):
+            if not isinstance(binary, dict):
+                raise ValidationError(f"{prefix}.binaries[{bidx}] must be a table")
+            bprefix = f"{prefix}.binaries[{bidx}]"
+            _expect_non_empty_str(binary, "name", bprefix)
+            _expect_non_empty_str(binary, "path", bprefix)
+
+        completions = artifact.get("completions", [])
+        if not isinstance(completions, list):
+            raise ValidationError(f"{prefix}.completions must be an array when present")
+        for cidx, completion in enumerate(completions):
+            if not isinstance(completion, dict):
+                raise ValidationError(f"{prefix}.completions[{cidx}] must be a table")
+            cprefix = f"{prefix}.completions[{cidx}]"
+            _expect_non_empty_str(completion, "shell", cprefix)
+            _expect_non_empty_str(completion, "path", cprefix)
+
+        gui_apps = artifact.get("gui_apps", [])
+        if not isinstance(gui_apps, list):
+            raise ValidationError(f"{prefix}.gui_apps must be an array when present")
+        for gidx, gui_app in enumerate(gui_apps):
+            if not isinstance(gui_app, dict):
+                raise ValidationError(f"{prefix}.gui_apps[{gidx}] must be a table")
+            gprefix = f"{prefix}.gui_apps[{gidx}]"
+            _expect_non_empty_str(gui_app, "app_id", gprefix)
+            _expect_non_empty_str(gui_app, "display_name", gprefix)
+            _expect_non_empty_str(gui_app, "exec", gprefix)
+            categories = gui_app.get("categories")
+            if not isinstance(categories, list) or not categories:
+                raise ValidationError(f"{gprefix}.categories must be a non-empty array")
+            for cat_idx, category in enumerate(categories):
+                if not isinstance(category, str) or not category.strip():
+                    raise ValidationError(
+                        f"{gprefix}.categories[{cat_idx}] must be a non-empty string"
+                    )
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate registry source configuration"
+    )
+    parser.add_argument("configs", nargs="+", type=Path, help="registry/sources/*.toml")
+    args = parser.parse_args(argv)
+
+    errors: list[str] = []
+    for path in args.configs:
+        try:
+            doc = tomllib.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(doc, dict):
+                raise ValidationError("manifest root must be a table")
+            validate_source_config(doc)
+        except FileNotFoundError:
+            errors.append(f"{path}: file not found")
+        except tomllib.TOMLDecodeError as exc:
+            errors.append(f"{path}: invalid TOML ({exc})")
+        except ValidationError as exc:
+            errors.append(f"{path}: {exc}")
+
+    if errors:
+        print("Source config validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print(f"Validation passed: {len(args.configs)} source config(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/upstream-release-bot.py
+++ b/scripts/upstream-release-bot.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
+
+
+class PlannedUpdate:
+    def __init__(self, package: str, version: str, config_path: Path, release: dict):
+        self.package = package
+        self.version = version
+        self.config_path = config_path
+        self.release = release
+
+
+def _load_generator_module(repo_root: Path):
+    script_path = repo_root / "scripts" / "registry-generate-manifest.py"
+    spec = importlib.util.spec_from_file_location(
+        "registry_generate_manifest", script_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load module from {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _http_get_json(url: str, token: str | None = None) -> object:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "crosspack-registry-upstream-bot",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
+        return json.loads(response.read().decode("utf-8"))
+
+
+def fetch_github_releases(repo: str, token: str | None = None) -> list[dict]:
+    url = f"https://api.github.com/repos/{repo}/releases?per_page=20"
+    payload = _http_get_json(url, token=token)
+    if not isinstance(payload, list):
+        raise RuntimeError(f"Unexpected releases response for {repo}")
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def normalize_tag_to_version(tag: str, tag_prefix: str | None = None) -> str | None:
+    if not tag:
+        return None
+    value = tag.strip()
+    if tag_prefix:
+        if not value.startswith(tag_prefix):
+            return None
+        value = value[len(tag_prefix) :]
+    elif value.startswith("v"):
+        value = value[1:]
+
+    if SEMVER_RE.fullmatch(value):
+        return value
+    return None
+
+
+def load_config(path: Path) -> dict:
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise RuntimeError(f"Invalid config root: {path}")
+    return data
+
+
+def plan_updates_for_config(
+    *, config_path: Path, index_root: Path, releases: list[dict]
+) -> list[PlannedUpdate]:
+    config = load_config(config_path)
+    package = str(config["name"])
+    source = config.get("source", {})
+    if not isinstance(source, dict):
+        raise RuntimeError(f"source must be a table in {config_path}")
+
+    include_prereleases = bool(source.get("include_prereleases", False))
+    tag_prefix = source.get("tag_prefix")
+    if tag_prefix is not None and not isinstance(tag_prefix, str):
+        raise RuntimeError(f"tag_prefix must be a string in {config_path}")
+
+    existing_versions = {
+        p.stem for p in (index_root / package).glob("*.toml") if p.is_file()
+    }
+
+    for release in releases:
+        if release.get("draft") is True:
+            continue
+        if release.get("prerelease") is True and not include_prereleases:
+            continue
+
+        tag_name = release.get("tag_name")
+        if not isinstance(tag_name, str):
+            continue
+
+        version = normalize_tag_to_version(tag_name, tag_prefix)
+        if version is None:
+            continue
+        if version in existing_versions:
+            return []
+
+        return [
+            PlannedUpdate(
+                package=package,
+                version=version,
+                config_path=config_path,
+                release=release,
+            )
+        ]
+    return []
+
+
+def _run(cmd: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, check=True, text=True, capture_output=True)
+
+
+def _open_or_update_pr(
+    *,
+    repo_root: Path,
+    manifest_path: Path,
+    package: str,
+    version: str,
+    base_branch: str,
+    branch_prefix: str,
+) -> None:
+    branch_name = f"{branch_prefix}/{package}/{version}"
+    title = f"chore(registry): add {package} {version}"
+    body = (
+        "## Summary\n"
+        f"- add generated registry manifest for `{package}` `{version}`\n"
+        "- produced by upstream release bot\n"
+    )
+
+    _run(["git", "checkout", base_branch], cwd=repo_root)
+    remote_branch = _run(
+        ["git", "ls-remote", "--heads", "origin", branch_name],
+        cwd=repo_root,
+    )
+    if remote_branch.stdout.strip():
+        _run(["git", "fetch", "origin", branch_name], cwd=repo_root)
+        _run(
+            ["git", "switch", "-C", branch_name, f"origin/{branch_name}"], cwd=repo_root
+        )
+    else:
+        _run(["git", "switch", "-C", branch_name, base_branch], cwd=repo_root)
+    _run(["git", "add", str(manifest_path)], cwd=repo_root)
+    staged = _run(["git", "diff", "--cached", "--name-only"], cwd=repo_root)
+    if not staged.stdout.strip():
+        return
+
+    _run(["git", "commit", "-m", title], cwd=repo_root)
+    _run(["git", "push", "-u", "origin", branch_name], cwd=repo_root)
+
+    existing = _run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--head",
+            branch_name,
+            "--state",
+            "open",
+            "--json",
+            "number",
+        ],
+        cwd=repo_root,
+    )
+    found = json.loads(existing.stdout)
+    if isinstance(found, list) and found:
+        print(f"PR already open for {branch_name}")
+        return
+
+    _run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--base",
+            base_branch,
+            "--head",
+            branch_name,
+            "--title",
+            title,
+            "--body",
+            body,
+        ],
+        cwd=repo_root,
+    )
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate/update manifests from upstream releases"
+    )
+    parser.add_argument(
+        "--sources-root",
+        type=Path,
+        default=Path("registry/sources"),
+        help="Path containing source configs",
+    )
+    parser.add_argument(
+        "--index-root",
+        type=Path,
+        default=Path("index"),
+        help="Registry index directory",
+    )
+    parser.add_argument("--package", action="append", help="Limit to package name")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print actions without writing"
+    )
+    parser.add_argument(
+        "--create-prs",
+        action="store_true",
+        help="Commit changes and open PRs with gh",
+    )
+    parser.add_argument("--base-branch", default="main")
+    parser.add_argument("--branch-prefix", default="upstream-release")
+    args = parser.parse_args(argv)
+
+    repo_root = Path.cwd()
+    generator = _load_generator_module(repo_root)
+
+    package_filter = set(args.package or [])
+    config_paths = sorted(args.sources_root.glob("*.toml"))
+    if package_filter:
+        config_paths = [p for p in config_paths if p.stem in package_filter]
+
+    if not config_paths:
+        print("No source configs selected")
+        return 0
+
+    github_token = __import__("os").environ.get("GITHUB_TOKEN")
+    planned: list[PlannedUpdate] = []
+    for config_path in config_paths:
+        config = load_config(config_path)
+        source = config.get("source")
+        if not isinstance(source, dict):
+            raise RuntimeError(f"Missing source table in {config_path}")
+        repo = source.get("repo")
+        if not isinstance(repo, str):
+            raise RuntimeError(f"Missing source.repo in {config_path}")
+
+        releases = fetch_github_releases(repo, token=github_token)
+        planned.extend(
+            plan_updates_for_config(
+                config_path=config_path,
+                index_root=args.index_root,
+                releases=releases,
+            )
+        )
+
+    if not planned:
+        print("No new releases detected")
+        return 0
+
+    created = 0
+    for update in planned:
+        manifest_path = args.index_root / update.package / f"{update.version}.toml"
+        if manifest_path.exists():
+            continue
+
+        if args.dry_run:
+            print(f"[dry-run] would generate {manifest_path}")
+            created += 1
+            continue
+
+        manifest_text = generator.generate_manifest_text(
+            config_path=update.config_path,
+            version=update.version,
+            release=update.release,
+        )
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(manifest_text, encoding="utf-8")
+        print(f"Generated {manifest_path}")
+        created += 1
+
+        if args.create_prs:
+            _open_or_update_pr(
+                repo_root=repo_root,
+                manifest_path=manifest_path,
+                package=update.package,
+                version=update.version,
+                base_branch=args.base_branch,
+                branch_prefix=args.branch_prefix,
+            )
+
+    print(f"Planned {len(planned)} update(s), created {created} manifest(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_registry_generate_manifest.py
+++ b/tests/test_registry_generate_manifest.py
@@ -1,0 +1,91 @@
+import hashlib
+import importlib.util
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "registry-generate-manifest.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "registry_generate_manifest", SCRIPT_PATH
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load script module from {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class RegistryGenerateManifestTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.generator = load_module()
+
+    def test_generates_manifest_with_downloaded_sha(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="manifest-gen-") as tmp:
+            tmp_path = Path(tmp)
+            config_path = tmp_path / "ripgrep.toml"
+            config_path.write_text(
+                textwrap.dedent(
+                    """
+                    name = "ripgrep"
+                    license = "MIT OR Unlicense"
+                    homepage = "https://github.com/BurntSushi/ripgrep"
+
+                    [source]
+                    provider = "github"
+                    repo = "BurntSushi/ripgrep"
+
+                    [[artifacts]]
+                    target = "x86_64-unknown-linux-gnu"
+                    asset = "ripgrep-{version}-x86_64-unknown-linux-musl.tar.gz"
+                    archive = "tar.gz"
+                    strip_components = 1
+
+                    [[artifacts.binaries]]
+                    name = "rg"
+                    path = "rg"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            release = {
+                "tag_name": "15.1.0",
+                "assets": [
+                    {
+                        "name": "ripgrep-15.1.0-x86_64-unknown-linux-musl.tar.gz",
+                        "browser_download_url": "https://example.invalid/ripgrep.tar.gz",
+                    }
+                ],
+            }
+
+            payload = b"ripgrep-linux-payload"
+            expected_sha = hashlib.sha256(payload).hexdigest()
+
+            def fake_download(_url: str, dest: Path) -> None:
+                dest.write_bytes(payload)
+
+            rendered = self.generator.generate_manifest_text(
+                config_path=config_path,
+                version="15.1.0",
+                release=release,
+                downloader=fake_download,
+            )
+
+            self.assertIn('name = "ripgrep"', rendered)
+            self.assertIn('version = "15.1.0"', rendered)
+            self.assertIn(
+                'url = "https://example.invalid/ripgrep.tar.gz"',
+                rendered,
+            )
+            self.assertIn(f'sha256 = "{expected_sha}"', rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_registry_validate_source.py
+++ b/tests/test_registry_validate_source.py
@@ -1,0 +1,130 @@
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "registry-validate-source.py"
+
+
+class RegistryValidateSourceTests(unittest.TestCase):
+    def test_every_indexed_package_has_source_config(self) -> None:
+        index_root = REPO_ROOT / "index"
+        sources_root = REPO_ROOT / "registry" / "sources"
+        indexed_packages = {p.name for p in index_root.iterdir() if p.is_dir()}
+        source_packages = {p.stem for p in sources_root.glob("*.toml")}
+
+        missing = sorted(indexed_packages - source_packages)
+        self.assertEqual(missing, [], msg=f"Missing source configs: {missing}")
+
+    def test_valid_source_config_passes(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="source-config-") as tmp:
+            config = Path(tmp) / "ripgrep.toml"
+            config.write_text(
+                textwrap.dedent(
+                    """
+                    name = "ripgrep"
+                    license = "MIT OR Unlicense"
+                    homepage = "https://github.com/BurntSushi/ripgrep"
+
+                    [source]
+                    provider = "github"
+                    repo = "BurntSushi/ripgrep"
+
+                    [[artifacts]]
+                    target = "x86_64-unknown-linux-gnu"
+                    asset = "ripgrep-{version}-x86_64-unknown-linux-musl.tar.gz"
+                    archive = "tar.gz"
+                    strip_components = 1
+
+                    [[artifacts.binaries]]
+                    name = "rg"
+                    path = "rg"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                ["python3", str(SCRIPT), str(config)],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+            )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("Validation passed", result.stdout)
+
+    def test_missing_required_source_fields_fails(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="source-config-") as tmp:
+            config = Path(tmp) / "ripgrep.toml"
+            config.write_text(
+                textwrap.dedent(
+                    """
+                    name = "ripgrep"
+                    license = "MIT OR Unlicense"
+                    homepage = "https://github.com/BurntSushi/ripgrep"
+
+                    [source]
+                    provider = "github"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                ["python3", str(SCRIPT), str(config)],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("manifest.source.repo", result.stderr)
+
+    def test_strip_components_rejects_boolean_values(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="source-config-") as tmp:
+            config = Path(tmp) / "ripgrep.toml"
+            config.write_text(
+                textwrap.dedent(
+                    """
+                    name = "ripgrep"
+                    license = "MIT OR Unlicense"
+                    homepage = "https://github.com/BurntSushi/ripgrep"
+
+                    [source]
+                    provider = "github"
+                    repo = "BurntSushi/ripgrep"
+
+                    [[artifacts]]
+                    target = "x86_64-unknown-linux-gnu"
+                    asset = "ripgrep-{version}-x86_64-unknown-linux-musl.tar.gz"
+                    archive = "tar.gz"
+                    strip_components = true
+
+                    [[artifacts.binaries]]
+                    name = "rg"
+                    path = "rg"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                ["python3", str(SCRIPT), str(config)],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("strip_components", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_upstream_release_bot.py
+++ b/tests/test_upstream_release_bot.py
@@ -1,0 +1,126 @@
+import importlib.util
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "upstream-release-bot.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("upstream_release_bot", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load script module from {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class UpstreamReleaseBotTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.bot = load_module()
+
+    def test_plan_updates_only_considers_latest_release(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-") as tmp:
+            tmp_path = Path(tmp)
+            sources_dir = tmp_path / "registry" / "sources"
+            sources_dir.mkdir(parents=True)
+            config_path = sources_dir / "ripgrep.toml"
+            config_path.write_text(
+                textwrap.dedent(
+                    """
+                    name = "ripgrep"
+                    license = "MIT OR Unlicense"
+                    homepage = "https://github.com/BurntSushi/ripgrep"
+
+                    [source]
+                    provider = "github"
+                    repo = "BurntSushi/ripgrep"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            existing_manifest = tmp_path / "index" / "ripgrep" / "15.1.0.toml"
+            existing_manifest.parent.mkdir(parents=True)
+            existing_manifest.write_text('name = "ripgrep"\n', encoding="utf-8")
+
+            releases = [
+                {
+                    "tag_name": "15.2.0",
+                    "draft": False,
+                    "prerelease": False,
+                    "assets": [],
+                },
+                {
+                    "tag_name": "15.1.0",
+                    "draft": False,
+                    "prerelease": False,
+                    "assets": [],
+                },
+            ]
+
+            planned = self.bot.plan_updates_for_config(
+                config_path=config_path,
+                index_root=tmp_path / "index",
+                releases=releases,
+            )
+
+        self.assertEqual(len(planned), 1)
+        self.assertEqual(planned[0].version, "15.2.0")
+
+    def test_plan_updates_stops_when_latest_release_exists(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-") as tmp:
+            tmp_path = Path(tmp)
+            sources_dir = tmp_path / "registry" / "sources"
+            sources_dir.mkdir(parents=True)
+            config_path = sources_dir / "ripgrep.toml"
+            config_path.write_text(
+                textwrap.dedent(
+                    """
+                    name = "ripgrep"
+                    license = "MIT OR Unlicense"
+                    homepage = "https://github.com/BurntSushi/ripgrep"
+
+                    [source]
+                    provider = "github"
+                    repo = "BurntSushi/ripgrep"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            existing_manifest = tmp_path / "index" / "ripgrep" / "15.2.0.toml"
+            existing_manifest.parent.mkdir(parents=True)
+            existing_manifest.write_text('name = "ripgrep"\n', encoding="utf-8")
+
+            releases = [
+                {
+                    "tag_name": "15.2.0",
+                    "draft": False,
+                    "prerelease": False,
+                    "assets": [],
+                },
+                {
+                    "tag_name": "15.1.0",
+                    "draft": False,
+                    "prerelease": False,
+                    "assets": [],
+                },
+            ]
+
+            planned = self.bot.plan_updates_for_config(
+                config_path=config_path,
+                index_root=tmp_path / "index",
+                releases=releases,
+            )
+
+        self.assertEqual(planned, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an upstream release bot workflow and Python tooling to detect new GitHub releases, generate deterministic manifests, and open deduplicated PRs
- introduce validated `registry/sources/*.toml` package configs for all currently indexed packages (including newly added GUI packages)
- document the automation flow and add tests that validate source schema, generation behavior, and full index-to-source coverage

## Verification
- `python3 -m unittest discover -s tests -v`
- `python3 scripts/registry-validate-source.py registry/sources/*.toml`
- `python3 scripts/upstream-release-bot.py --dry-run`