### PR TITLE
feat(registry): add seed definition validation for SPI-12

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,11 @@ Manifest updates do not need to be hand-authored for configured packages.
 Useful commands:
 
 ```bash
+# Validate seed definitions + coverage
+python3 scripts/registry-validate-seed-definitions.py registry/seed-definitions.toml
+
 # Validate source configs
-python3 scripts/registry-validate-source.py registry/sources/*.toml
+python3 scripts/registry-validate-source.py --require-package-coverage registry/sources/*.toml
 
 # Dry-run release detection and generation planning
 python3 scripts/upstream-release-bot.py --dry-run
@@ -63,6 +66,8 @@ python3 scripts/upstream-release-bot.py --dry-run
 # Limit to a single package
 python3 scripts/upstream-release-bot.py --dry-run --package ripgrep
 ```
+
+For operator review/update steps, see `scripts/registry-seed-runbook.md`.
 
 ## Registry Preflight (Local + CI)
 

--- a/registry/seed-definitions.toml
+++ b/registry/seed-definitions.toml
@@ -1,0 +1,101 @@
+[[seeds]]
+package = "bat"
+category = "cli"
+rationale = "Common terminal UX upgrade and representative Rust CLI package."
+review_notes = "Keep GitHub release assets aligned with tar.gz archives and bat binary paths."
+
+[[seeds]]
+package = "beekeeper-studio"
+category = "desktop-app"
+rationale = "Flagship GUI SQL client covering AppImage, DMG, and portable Windows delivery."
+review_notes = "Verify GUI app metadata stays aligned with portable asset names for each platform."
+
+[[seeds]]
+package = "bruno"
+category = "desktop-app"
+rationale = "Modern API client with cross-platform desktop packaging and release automation needs."
+review_notes = "Review archive layout and desktop entry metadata whenever upstream asset names change."
+
+[[seeds]]
+package = "crosspack"
+category = "runtime"
+rationale = "Registry’s own distribution package and the core path operators care about first."
+review_notes = "Confirm tag_prefix=v remains correct and keep alias binary coverage for cpk on Windows."
+
+[[seeds]]
+package = "dbeaver"
+category = "database"
+rationale = "Large multi-platform desktop database client that exercises archive and app bundle patterns."
+review_notes = "Check tarball root paths and DBeaver.app binary paths when upstream repackages releases."
+
+[[seeds]]
+package = "delta"
+category = "cli"
+rationale = "Popular CLI companion package that expands seed coverage beyond the initial shell tooling set."
+review_notes = "Keep binary path expectations aligned with upstream archive layout and GitHub tags."
+
+[[seeds]]
+package = "fd"
+category = "utility"
+rationale = "Widely used search utility with predictable release structure and fast operator validation."
+review_notes = "Review musl vs gnu archive names and keep binary extraction paths stable across targets."
+
+[[seeds]]
+package = "fzf"
+category = "shell"
+rationale = "Core shell workflow package with tarball conventions that operators frequently inspect."
+review_notes = "Double-check versioned archive naming and completion asset paths when upstream changes packaging."
+
+[[seeds]]
+package = "gh"
+category = "developer-tool"
+rationale = "Essential developer workflow tool and a clean example of GitHub CLI multi-platform assets."
+review_notes = "Ensure zip/tar.gz assets still unpack to bin/gh or bin/gh.exe across supported platforms."
+
+[[seeds]]
+package = "insomnia"
+category = "desktop-app"
+rationale = "Cross-platform API desktop client with GUI metadata and multiple archive formats."
+review_notes = "Validate DMG and portable archive conventions if upstream renames assets or app bundles."
+
+[[seeds]]
+package = "jq"
+category = "utility"
+rationale = "Canonical lightweight CLI package that operators can validate quickly during registry reviews."
+review_notes = "Keep single-binary asset names aligned with target mappings and release version coverage."
+
+[[seeds]]
+package = "lazygit"
+category = "developer-tool"
+rationale = "Popular TUI developer tool that exercises tarball and zip extraction paths."
+review_notes = "Watch for archive layout changes that would break binary path assumptions across platforms."
+
+[[seeds]]
+package = "neovide"
+category = "editor"
+rationale = "GUI editor seed that covers Linux tarballs, macOS app bundles, and Windows zips."
+review_notes = "Review Neovide.app bundle paths and static asset names when upstream release packaging changes."
+
+[[seeds]]
+package = "redisinsight"
+category = "database"
+rationale = "GUI database tooling seed with desktop app metadata and portable package expectations."
+review_notes = "Confirm app IDs and executable names still match portable assets for each platform."
+
+[[seeds]]
+package = "ripgrep"
+category = "utility"
+rationale = "Foundational CLI search tool and a representative source-config-driven package for validation."
+review_notes = "Keep archive template names aligned with upstream musl and platform artifact naming."
+
+[[seeds]]
+package = "starship"
+category = "shell"
+rationale = "Common shell prompt dependency with straightforward release patterns and operator familiarity."
+review_notes = "Verify binary-only assets and shell completion metadata stay aligned with upstream artifacts."
+
+[[seeds]]
+package = "uv"
+category = "developer-tool"
+rationale = "Fast-moving flagship Python tooling package that keeps source validation paths exercised."
+review_notes = "Review version churn frequently and ensure per-target archives still match generated manifests."

--- a/scripts/registry-seed-runbook.md
+++ b/scripts/registry-seed-runbook.md
@@ -1,0 +1,53 @@
+# Registry seed definitions runbook
+
+Use this runbook when reviewing or updating the first Crosspack Registry seed set.
+
+## Seed source of truth
+
+- Seed catalog: `registry/seed-definitions.toml`
+- Package templates: `packages/*.toml`
+- Source configs: `registry/sources/*.toml`
+- Release manifests: `releases/<package>/*.toml`
+
+## Review checklist
+
+1. Confirm every package template in `packages/` has exactly one `[[seeds]]` entry.
+2. Confirm each seed entry has:
+   - `package`
+   - `category`
+   - `rationale`
+   - `review_notes`
+3. Check that each seeded package still has:
+   - a matching source config in `registry/sources/`
+   - at least one release manifest under `releases/<package>/`
+4. If package metadata changed, validate the corresponding package and release manifests too.
+
+## Validation commands
+
+```bash
+python3 scripts/registry-validate-seed-definitions.py registry/seed-definitions.toml
+python3 scripts/registry-validate-source.py --require-package-coverage registry/sources/*.toml
+REGISTRY_PREFLIGHT_ALL=1 REGISTRY_PREFLIGHT_SKIP_SMOKE=1 ./scripts/registry-preflight.sh
+python3 -m unittest \
+  tests.test_registry_validate_seed_definitions \
+  tests.test_registry_validate_source \
+  tests.test_registry_validate \
+  tests.test_registry_generate_manifest \
+  tests.test_upstream_release_bot -v
+```
+
+## Update procedure
+
+1. Edit `registry/seed-definitions.toml`.
+2. If adding or removing a package from the seed set, update package/source/release coverage in the repo first.
+3. Run the validation commands above.
+4. Open a PR summarizing:
+   - which seed entries changed
+   - whether package/source/release coverage changed
+   - the validation commands you ran
+
+## Scope guardrails
+
+- Keep the seed file tightly focused on the flagship package set already present in the registry.
+- Do not add speculative fields or alternate registry schemas in this file.
+- Treat the runbook and validator as the repeatable operator path for future seed reviews.

--- a/scripts/registry-validate-seed-definitions.py
+++ b/scripts/registry-validate-seed-definitions.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+class ValidationError(Exception):
+    pass
+
+
+ALLOWED_CATEGORIES = {
+    "cli",
+    "developer-tool",
+    "database",
+    "desktop-app",
+    "editor",
+    "runtime",
+    "shell",
+    "utility",
+}
+
+
+def _load_toml(path: Path) -> dict:
+    try:
+        doc = tomllib.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValidationError(f"{path}: file not found") from exc
+    except tomllib.TOMLDecodeError as exc:
+        raise ValidationError(f"{path}: invalid TOML ({exc})") from exc
+    if not isinstance(doc, dict):
+        raise ValidationError(f"{path}: manifest root must be a table")
+    return doc
+
+
+def _expect_non_empty_string(obj: dict, key: str, ctx: str) -> str:
+    value = obj.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{ctx}.{key} must be a non-empty string")
+    return value.strip()
+
+
+def _package_names(root: Path) -> set[str]:
+    if not root.is_dir():
+        raise ValidationError(f"{root}: packages root not found")
+    return {path.stem for path in root.glob("*.toml") if path.is_file()}
+
+
+def _source_names(root: Path) -> set[str]:
+    if not root.is_dir():
+        raise ValidationError(f"{root}: sources root not found")
+    return {path.stem for path in root.glob("*.toml") if path.is_file()}
+
+
+def _release_names(root: Path) -> set[str]:
+    if not root.is_dir():
+        raise ValidationError(f"{root}: releases root not found")
+    names: set[str] = set()
+    for pkg_dir in root.iterdir():
+        if not pkg_dir.is_dir():
+            continue
+        if any(path.is_file() and path.suffix == ".toml" for path in pkg_dir.glob("*.toml")):
+            names.add(pkg_dir.name)
+    return names
+
+
+def validate_seed_definitions(
+    doc: dict,
+    *,
+    packages_root: Path,
+    sources_root: Path,
+    releases_root: Path,
+) -> int:
+    seeds = doc.get("seeds")
+    if not isinstance(seeds, list) or not seeds:
+        raise ValidationError("seed-definitions.seeds must be a non-empty array")
+
+    seen_packages: set[str] = set()
+    for idx, seed in enumerate(seeds):
+        if not isinstance(seed, dict):
+            raise ValidationError(f"seed-definitions.seeds[{idx}] must be a table")
+        ctx = f"seed-definitions.seeds[{idx}]"
+        package = _expect_non_empty_string(seed, "package", ctx)
+        if package in seen_packages:
+            raise ValidationError(f"{ctx}.package duplicates package '{package}'")
+        seen_packages.add(package)
+
+        category = _expect_non_empty_string(seed, "category", ctx)
+        if category not in ALLOWED_CATEGORIES:
+            allowed = ", ".join(sorted(ALLOWED_CATEGORIES))
+            raise ValidationError(f"{ctx}.category must be one of: {allowed}")
+
+        _expect_non_empty_string(seed, "rationale", ctx)
+        _expect_non_empty_string(seed, "review_notes", ctx)
+
+    package_names = _package_names(packages_root)
+    source_names = _source_names(sources_root)
+    release_names = _release_names(releases_root)
+
+    missing_seed_definitions = sorted(package_names - seen_packages)
+    if missing_seed_definitions:
+        raise ValidationError(
+            "missing seed definitions for package template(s): "
+            + ", ".join(missing_seed_definitions)
+        )
+
+    unknown_seed_packages = sorted(seen_packages - package_names)
+    if unknown_seed_packages:
+        raise ValidationError(
+            "seed definitions reference unknown package template(s): "
+            + ", ".join(unknown_seed_packages)
+        )
+
+    missing_sources = sorted(seen_packages - source_names)
+    if missing_sources:
+        raise ValidationError(
+            "missing source configs for seed package(s): " + ", ".join(missing_sources)
+        )
+
+    missing_releases = sorted(seen_packages - release_names)
+    if missing_releases:
+        raise ValidationError(
+            "missing release manifests for seed package(s): " + ", ".join(missing_releases)
+        )
+
+    return len(seeds)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Validate Crosspack seed definitions")
+    parser.add_argument(
+        "seed_definitions",
+        type=Path,
+        help="Path to registry/seed-definitions.toml",
+    )
+    parser.add_argument(
+        "--packages-root",
+        type=Path,
+        default=Path("packages"),
+        help="Package template root",
+    )
+    parser.add_argument(
+        "--sources-root",
+        type=Path,
+        default=Path("registry") / "sources",
+        help="Source config root",
+    )
+    parser.add_argument(
+        "--releases-root",
+        type=Path,
+        default=Path("releases"),
+        help="Release manifest root",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        count = validate_seed_definitions(
+            _load_toml(args.seed_definitions),
+            packages_root=args.packages_root,
+            sources_root=args.sources_root,
+            releases_root=args.releases_root,
+        )
+    except ValidationError as exc:
+        print("Seed definition validation failed:", file=sys.stderr)
+        print(f"  - {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Seed definition validation passed: {count} seed package(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_registry_validate_seed_definitions.py
+++ b/tests/test_registry_validate_seed_definitions.py
@@ -1,0 +1,163 @@
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "registry-validate-seed-definitions.py"
+
+
+class RegistryValidateSeedDefinitionsTests(unittest.TestCase):
+    def test_valid_seed_definitions_pass(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="seed-definitions-") as tmp:
+            tmp_path = Path(tmp)
+            seeds = tmp_path / "registry" / "seed-definitions.toml"
+            packages_root = tmp_path / "packages"
+            sources_root = tmp_path / "registry" / "sources"
+            releases_root = tmp_path / "releases"
+            packages_root.mkdir(parents=True, exist_ok=True)
+            sources_root.mkdir(parents=True, exist_ok=True)
+            (releases_root / "demo").mkdir(parents=True, exist_ok=True)
+
+            seeds.write_text(
+                textwrap.dedent(
+                    """
+                    [[seeds]]
+                    package = "demo"
+                    category = "cli"
+                    rationale = "Representative command-line package"
+                    review_notes = "Keep source and release coverage current"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            (packages_root / "demo.toml").write_text('name = "demo"\n', encoding="utf-8")
+            (sources_root / "demo.toml").write_text('name = "demo"\n', encoding="utf-8")
+            (releases_root / "demo" / "1.2.3.toml").write_text(
+                'name = "demo"\nversion = "1.2.3"\n', encoding="utf-8"
+            )
+
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(SCRIPT),
+                    str(seeds),
+                    "--packages-root",
+                    str(packages_root),
+                    "--sources-root",
+                    str(sources_root),
+                    "--releases-root",
+                    str(releases_root),
+                ],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+            )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("Seed definition validation passed", result.stdout)
+
+    def test_missing_release_coverage_fails(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="seed-definitions-") as tmp:
+            tmp_path = Path(tmp)
+            seeds = tmp_path / "registry" / "seed-definitions.toml"
+            packages_root = tmp_path / "packages"
+            sources_root = tmp_path / "registry" / "sources"
+            releases_root = tmp_path / "releases"
+            packages_root.mkdir(parents=True, exist_ok=True)
+            sources_root.mkdir(parents=True, exist_ok=True)
+            releases_root.mkdir(parents=True, exist_ok=True)
+
+            seeds.write_text(
+                textwrap.dedent(
+                    """
+                    [[seeds]]
+                    package = "demo"
+                    category = "cli"
+                    rationale = "Representative command-line package"
+                    review_notes = "Keep source and release coverage current"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            (packages_root / "demo.toml").write_text('name = "demo"\n', encoding="utf-8")
+            (sources_root / "demo.toml").write_text('name = "demo"\n', encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(SCRIPT),
+                    str(seeds),
+                    "--packages-root",
+                    str(packages_root),
+                    "--sources-root",
+                    str(sources_root),
+                    "--releases-root",
+                    str(releases_root),
+                ],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("missing release manifests", result.stderr)
+
+    def test_seed_catalog_must_match_package_templates(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="seed-definitions-") as tmp:
+            tmp_path = Path(tmp)
+            seeds = tmp_path / "registry" / "seed-definitions.toml"
+            packages_root = tmp_path / "packages"
+            sources_root = tmp_path / "registry" / "sources"
+            releases_root = tmp_path / "releases"
+            packages_root.mkdir(parents=True, exist_ok=True)
+            sources_root.mkdir(parents=True, exist_ok=True)
+            (releases_root / "demo").mkdir(parents=True, exist_ok=True)
+
+            seeds.write_text(
+                textwrap.dedent(
+                    """
+                    [[seeds]]
+                    package = "demo"
+                    category = "cli"
+                    rationale = "Representative command-line package"
+                    review_notes = "Keep source and release coverage current"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            (packages_root / "demo.toml").write_text('name = "demo"\n', encoding="utf-8")
+            (packages_root / "extra.toml").write_text('name = "extra"\n', encoding="utf-8")
+            (sources_root / "demo.toml").write_text('name = "demo"\n', encoding="utf-8")
+            (releases_root / "demo" / "1.2.3.toml").write_text(
+                'name = "demo"\nversion = "1.2.3"\n', encoding="utf-8"
+            )
+
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(SCRIPT),
+                    str(seeds),
+                    "--packages-root",
+                    str(packages_root),
+                    "--sources-root",
+                    str(sources_root),
+                    "--releases-root",
+                    str(releases_root),
+                ],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("missing seed definitions", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add the initial 17-package seed catalog at 
- add a dedicated seed-definition validator and regression tests for coverage drift
- add an operator runbook and README guidance for reviewing/updating the seed set

## Testing
- python3 scripts/registry-validate-seed-definitions.py registry/seed-definitions.toml
- python3 scripts/registry-validate-source.py --require-package-coverage registry/sources/*.toml
- REGISTRY_PREFLIGHT_ALL=1 REGISTRY_PREFLIGHT_SKIP_SMOKE=1 ./scripts/registry-preflight.sh
- python3 -m unittest tests.test_registry_validate_seed_definitions tests.test_registry_validate_source tests.test_registry_validate tests.test_registry_generate_manifest tests.test_upstream_release_bot -v

Closes SPI-12