### PR TITLE
feat(registry): generalize source model for non-github distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,24 @@ Manifest updates do not need to be hand-authored for configured packages.
   - package template docs in `packages/`
   - release docs in `releases/<package>/`
 
+### Generalized source model
+
+Source configs now support a generalized schema under `[source.*]` so new upstream patterns can be expressed by composing release discovery, checksum loading, and asset URL behavior instead of adding a new top-level provider enum by default.
+
+Current supported strategies:
+
+- `[source.release]`
+  - `kind = "github_releases"` with `repo` and optional `tag_prefix` / `include_prereleases`
+  - `kind = "node_dist_index"` with `major` and optional `include_prereleases`
+- `[source.checksum]`
+  - `kind = "download_sha256"` for GitHub-style releases where the registry hashes downloaded assets
+  - `kind = "shasums256"` with `url_template` for upstreams that publish a checksum manifest
+- `[source.asset]`
+  - `kind = "release_asset_url"` for direct release asset URLs from the release feed
+  - `kind = "templated"` with `base_url` for deterministic URL construction from artifact templates
+
+Legacy `provider = "github"` and `provider = "nodejs-dist"` source definitions are still normalized by tooling for compatibility during migration, but new configs should prefer the generalized `[source.release]`, `[source.checksum]`, and `[source.asset]` tables.
+
 Useful commands:
 
 ```bash

--- a/packages/node.toml
+++ b/packages/node.toml
@@ -2,10 +2,18 @@ name = "node"
 license = "MIT"
 homepage = "https://nodejs.org/"
 
-[source]
-provider = "nodejs-dist"
+[source.release]
+kind = "node_dist_index"
 major = 22
 include_prereleases = false
+
+[source.checksum]
+kind = "shasums256"
+url_template = "https://nodejs.org/dist/latest-v22.x/SHASUMS256.txt"
+
+[source.asset]
+kind = "templated"
+base_url = "https://nodejs.org/dist/latest-v22.x"
 
 [[artifacts]]
 target = "x86_64-unknown-linux-gnu"

--- a/registry/sources/fd.toml
+++ b/registry/sources/fd.toml
@@ -2,11 +2,17 @@ name = "fd"
 license = "Apache-2.0 OR MIT"
 homepage = "https://github.com/sharkdp/fd"
 
-[source]
-provider = "github"
+[source.release]
+kind = "github_releases"
 repo = "sharkdp/fd"
 tag_prefix = "v"
 include_prereleases = false
+
+[source.checksum]
+kind = "download_sha256"
+
+[source.asset]
+kind = "release_asset_url"
 
 [[artifacts]]
 target = "x86_64-unknown-linux-gnu"

--- a/registry/sources/node.toml
+++ b/registry/sources/node.toml
@@ -2,10 +2,18 @@ name = "node"
 license = "MIT"
 homepage = "https://nodejs.org/"
 
-[source]
-provider = "nodejs-dist"
+[source.release]
+kind = "node_dist_index"
 major = 22
 include_prereleases = false
+
+[source.checksum]
+kind = "shasums256"
+url_template = "https://nodejs.org/dist/latest-v22.x/SHASUMS256.txt"
+
+[source.asset]
+kind = "templated"
+base_url = "https://nodejs.org/dist/latest-v22.x"
 
 [[artifacts]]
 target = "x86_64-unknown-linux-gnu"

--- a/scripts/registry-generate-manifest.py
+++ b/scripts/registry-generate-manifest.py
@@ -27,6 +27,9 @@ class DownloadError(Exception):
 
 NODE_DIST_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
 DOWNLOAD_ATTEMPTS = 3
+RELEASE_KIND_VALUES = {"github_releases", "node_dist_index"}
+CHECKSUM_KIND_VALUES = {"download_sha256", "shasums256"}
+ASSET_KIND_VALUES = {"release_asset_url", "templated"}
 
 
 def _escape(value: str) -> str:
@@ -88,17 +91,7 @@ def render_package_text(doc: dict) -> str:
 
     source = doc.get("source")
     if isinstance(source, dict):
-        chunks.append("[source]")
-        chunks.append(_line("provider", source["provider"]))
-        if "repo" in source:
-            chunks.append(_line("repo", source["repo"]))
-        if "major" in source:
-            chunks.append(_line("major", source["major"]))
-        if "tag_prefix" in source:
-            chunks.append(_line("tag_prefix", source["tag_prefix"]))
-        if "include_prereleases" in source:
-            chunks.append(_line("include_prereleases", source["include_prereleases"]))
-        chunks.append("")
+        render_source_text(chunks, source)
 
     artifacts = doc.get("artifacts")
     if not isinstance(artifacts, list) or not artifacts:
@@ -197,6 +190,81 @@ def _build_nodejs_dist_base_url(*, major: int) -> str:
     return f"https://nodejs.org/dist/latest-v{major}.x"
 
 
+def normalize_source(source: dict) -> dict:
+    release = source.get("release")
+    checksum = source.get("checksum")
+    asset = source.get("asset")
+    if isinstance(release, dict) and isinstance(checksum, dict) and isinstance(asset, dict):
+        return {"release": release, "checksum": checksum, "asset": asset}
+
+    provider = source.get("provider")
+    if provider == "github":
+        repo = source.get("repo")
+        if not isinstance(repo, str) or not repo:
+            raise GenerateError("github source config requires source.repo")
+        normalized_release = {
+            "kind": "github_releases",
+            "repo": repo,
+            "include_prereleases": bool(source.get("include_prereleases", False)),
+        }
+        tag_prefix = source.get("tag_prefix")
+        if isinstance(tag_prefix, str) and tag_prefix:
+            normalized_release["tag_prefix"] = tag_prefix
+        return {
+            "release": normalized_release,
+            "checksum": {"kind": "download_sha256"},
+            "asset": {"kind": "release_asset_url"},
+        }
+
+    if provider == "nodejs-dist":
+        major = source.get("major")
+        if isinstance(major, bool) or not isinstance(major, int) or major <= 0:
+            raise GenerateError("nodejs-dist source config requires source.major > 0")
+        base_url = _build_nodejs_dist_base_url(major=major)
+        return {
+            "release": {
+                "kind": "node_dist_index",
+                "major": major,
+                "include_prereleases": bool(source.get("include_prereleases", False)),
+            },
+            "checksum": {
+                "kind": "shasums256",
+                "url_template": f"{base_url}/SHASUMS256.txt",
+            },
+            "asset": {"kind": "templated", "base_url": base_url},
+        }
+
+    raise GenerateError(
+        "source config must define either release/checksum/asset tables or a supported legacy provider"
+    )
+
+
+def render_source_text(chunks: list[str], source: dict) -> None:
+    normalized = normalize_source(source)
+    release = normalized["release"]
+    checksum = normalized["checksum"]
+    asset = normalized["asset"]
+
+    chunks.append("[source.release]")
+    chunks.append(_line("kind", release["kind"]))
+    for key in ("repo", "tag_prefix", "include_prereleases", "major"):
+        if key in release:
+            chunks.append(_line(key, release[key]))
+    chunks.append("")
+
+    chunks.append("[source.checksum]")
+    chunks.append(_line("kind", checksum["kind"]))
+    if "url_template" in checksum:
+        chunks.append(_line("url_template", checksum["url_template"]))
+    chunks.append("")
+
+    chunks.append("[source.asset]")
+    chunks.append(_line("kind", asset["kind"]))
+    if "base_url" in asset:
+        chunks.append(_line("base_url", asset["base_url"]))
+    chunks.append("")
+
+
 def _build_nodejs_dist_release_artifacts(
     *,
     config: dict,
@@ -205,16 +273,21 @@ def _build_nodejs_dist_release_artifacts(
 ) -> list[dict]:
     source = config.get("source")
     if not isinstance(source, dict):
-        raise GenerateError("nodejs-dist source config requires a source table")
-    major = source.get("major")
+        raise GenerateError("source config requires a source table")
+    normalized = normalize_source(source)
+    release = normalized["release"]
+    asset = normalized["asset"]
+    major = release.get("major")
     if isinstance(major, bool) or not isinstance(major, int) or major <= 0:
-        raise GenerateError("nodejs-dist source config requires source.major > 0")
+        raise GenerateError("node dist release config requires release.major > 0")
     if not NODE_DIST_VERSION_RE.fullmatch(version):
-        raise GenerateError("nodejs-dist releases require a normalized semver version")
+        raise GenerateError("node dist releases require a normalized semver version")
     if shasums_by_name is None:
-        raise GenerateError("nodejs-dist generation requires shasums_by_name")
+        raise GenerateError("node dist generation requires shasums_by_name")
 
-    base_url = _build_nodejs_dist_base_url(major=major)
+    base_url = asset.get("base_url")
+    if not isinstance(base_url, str) or not base_url.startswith("https://"):
+        raise GenerateError("templated asset config requires source.asset.base_url")
     release_artifacts: list[dict] = []
     for artifact in config.get("artifacts", []):
         target = artifact["target"]
@@ -251,8 +324,9 @@ def generate_release_text(
     source = config.get("source")
     if not isinstance(source, dict):
         raise GenerateError("source config root requires a source table")
+    normalized = normalize_source(source)
 
-    if source.get("provider") == "nodejs-dist":
+    if normalized["release"].get("kind") == "node_dist_index":
         release_artifacts = _build_nodejs_dist_release_artifacts(
             config=config,
             version=version,

--- a/scripts/registry-validate-source.py
+++ b/scripts/registry-validate-source.py
@@ -19,6 +19,9 @@ class ValidationError(Exception):
 ARCHIVE_VALUES = {"tar.gz", "zip", "tar.xz", "tgz", "bin"}
 TARGET_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 REPO_RE = re.compile(r"^[^/\s]+/[^/\s]+$")
+RELEASE_KIND_VALUES = {"github_releases", "node_dist_index"}
+CHECKSUM_KIND_VALUES = {"download_sha256", "shasums256"}
+ASSET_KIND_VALUES = {"release_asset_url", "templated"}
 
 
 def _expect_non_empty_str(obj: dict, key: str, ctx: str) -> str:
@@ -47,25 +50,76 @@ def validate_source_config(doc: dict) -> None:
     if not isinstance(source, dict):
         raise ValidationError("manifest.source must be a table")
 
-    provider = _expect_non_empty_str(source, "provider", "manifest.source")
-    if provider == "github":
-        repo = _expect_non_empty_str(source, "repo", "manifest.source")
-        if not REPO_RE.fullmatch(repo):
-            raise ValidationError("manifest.source.repo must look like owner/name")
-    elif provider == "nodejs-dist":
-        major = source.get("major")
-        if isinstance(major, bool) or not isinstance(major, int) or major <= 0:
-            raise ValidationError("manifest.source.major must be an integer > 0")
+    release = source.get("release")
+    checksum = source.get("checksum")
+    asset = source.get("asset")
+
+    if isinstance(release, dict) and isinstance(checksum, dict) and isinstance(asset, dict):
+        release_kind = _expect_non_empty_str(release, "kind", "manifest.source.release")
+        if release_kind not in RELEASE_KIND_VALUES:
+            raise ValidationError(
+                "manifest.source.release.kind must be 'github_releases' or 'node_dist_index'"
+            )
+        if release_kind == "github_releases":
+            repo = _expect_non_empty_str(release, "repo", "manifest.source.release")
+            if not REPO_RE.fullmatch(repo):
+                raise ValidationError("manifest.source.release.repo must look like owner/name")
+        else:
+            major = release.get("major")
+            if isinstance(major, bool) or not isinstance(major, int) or major <= 0:
+                raise ValidationError("manifest.source.release.major must be an integer > 0")
+
+        include_prereleases = release.get("include_prereleases")
+        if include_prereleases is not None and not isinstance(include_prereleases, bool):
+            raise ValidationError("manifest.source.release.include_prereleases must be a boolean")
+
+        tag_prefix = release.get("tag_prefix")
+        if tag_prefix is not None and not isinstance(tag_prefix, str):
+            raise ValidationError("manifest.source.release.tag_prefix must be a string")
+
+        checksum_kind = _expect_non_empty_str(checksum, "kind", "manifest.source.checksum")
+        if checksum_kind not in CHECKSUM_KIND_VALUES:
+            raise ValidationError(
+                "manifest.source.checksum.kind must be 'download_sha256' or 'shasums256'"
+            )
+        if checksum_kind == "shasums256":
+            url_template = _expect_non_empty_str(
+                checksum, "url_template", "manifest.source.checksum"
+            )
+            if not url_template.startswith("https://"):
+                raise ValidationError(
+                    "manifest.source.checksum.url_template must start with https://"
+                )
+
+        asset_kind = _expect_non_empty_str(asset, "kind", "manifest.source.asset")
+        if asset_kind not in ASSET_KIND_VALUES:
+            raise ValidationError(
+                "manifest.source.asset.kind must be 'release_asset_url' or 'templated'"
+            )
+        if asset_kind == "templated":
+            base_url = _expect_non_empty_str(asset, "base_url", "manifest.source.asset")
+            if not base_url.startswith("https://"):
+                raise ValidationError("manifest.source.asset.base_url must start with https://")
     else:
-        raise ValidationError("manifest.source.provider must be 'github' or 'nodejs-dist'")
+        provider = _expect_non_empty_str(source, "provider", "manifest.source")
+        if provider == "github":
+            repo = _expect_non_empty_str(source, "repo", "manifest.source")
+            if not REPO_RE.fullmatch(repo):
+                raise ValidationError("manifest.source.repo must look like owner/name")
+        elif provider == "nodejs-dist":
+            major = source.get("major")
+            if isinstance(major, bool) or not isinstance(major, int) or major <= 0:
+                raise ValidationError("manifest.source.major must be an integer > 0")
+        else:
+            raise ValidationError("manifest.source.provider must be 'github' or 'nodejs-dist'")
 
-    include_prereleases = source.get("include_prereleases")
-    if include_prereleases is not None and not isinstance(include_prereleases, bool):
-        raise ValidationError("manifest.source.include_prereleases must be a boolean")
+        include_prereleases = source.get("include_prereleases")
+        if include_prereleases is not None and not isinstance(include_prereleases, bool):
+            raise ValidationError("manifest.source.include_prereleases must be a boolean")
 
-    tag_prefix = source.get("tag_prefix")
-    if tag_prefix is not None and not isinstance(tag_prefix, str):
-        raise ValidationError("manifest.source.tag_prefix must be a string")
+        tag_prefix = source.get("tag_prefix")
+        if tag_prefix is not None and not isinstance(tag_prefix, str):
+            raise ValidationError("manifest.source.tag_prefix must be a string")
 
     artifacts = doc.get("artifacts")
     if not isinstance(artifacts, list) or not artifacts:

--- a/scripts/registry-validate.py
+++ b/scripts/registry-validate.py
@@ -13,6 +13,9 @@ SIG_RE = re.compile(r"^[0-9a-fA-F]{128}$")
 TARGET_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 REPO_RE = re.compile(r"^[^/\s]+/[^/\s]+$")
 ARCHIVE_VALUES = {"tar.gz", "zip", "tar.xz", "tgz", "bin"}
+RELEASE_KIND_VALUES = {"github_releases", "node_dist_index"}
+CHECKSUM_KIND_VALUES = {"download_sha256", "shasums256"}
+ASSET_KIND_VALUES = {"release_asset_url", "templated"}
 
 
 def err(errors: list[str], path: Path, message: str) -> None:
@@ -77,30 +80,102 @@ def validate_package_manifest(path: Path, doc: dict, errors: list[str]) -> None:
     if not isinstance(source, dict):
         err(errors, path, "missing or invalid `source` (must be a table)")
     else:
-        provider_ok = expect_nonempty_str(
-            source.get("provider"), "source.provider", errors, path
-        )
-        provider = source.get("provider") if provider_ok else None
-        if provider == "github":
-            repo_ok = expect_nonempty_str(source.get("repo"), "source.repo", errors, path)
-            if repo_ok and not REPO_RE.fullmatch(str(source["repo"])):
-                err(errors, path, "source.repo must look like owner/name")
-        elif provider == "nodejs-dist":
-            major = source.get("major")
-            if isinstance(major, bool) or not isinstance(major, int) or major <= 0:
-                err(errors, path, "source.major must be an integer > 0")
-        elif provider_ok:
-            err(errors, path, "source.provider must be 'github' or 'nodejs-dist'")
+        release = source.get("release")
+        checksum = source.get("checksum")
+        asset = source.get("asset")
+        if isinstance(release, dict) and isinstance(checksum, dict) and isinstance(asset, dict):
+            release_kind_ok = expect_nonempty_str(
+                release.get("kind"), "source.release.kind", errors, path
+            )
+            release_kind = release.get("kind") if release_kind_ok else None
+            if release_kind_ok and release_kind not in RELEASE_KIND_VALUES:
+                err(
+                    errors,
+                    path,
+                    "source.release.kind must be 'github_releases' or 'node_dist_index'",
+                )
+            elif release_kind == "github_releases":
+                repo_ok = expect_nonempty_str(
+                    release.get("repo"), "source.release.repo", errors, path
+                )
+                if repo_ok and not REPO_RE.fullmatch(str(release["repo"])):
+                    err(errors, path, "source.release.repo must look like owner/name")
+            elif release_kind == "node_dist_index":
+                major = release.get("major")
+                if isinstance(major, bool) or not isinstance(major, int) or major <= 0:
+                    err(errors, path, "source.release.major must be an integer > 0")
 
-        include_prereleases = source.get("include_prereleases")
-        if include_prereleases is not None and not isinstance(
-            include_prereleases, bool
-        ):
-            err(errors, path, "source.include_prereleases must be a boolean")
+            include_prereleases = release.get("include_prereleases")
+            if include_prereleases is not None and not isinstance(
+                include_prereleases, bool
+            ):
+                err(errors, path, "source.release.include_prereleases must be a boolean")
 
-        tag_prefix = source.get("tag_prefix")
-        if tag_prefix is not None and not isinstance(tag_prefix, str):
-            err(errors, path, "source.tag_prefix must be a string")
+            tag_prefix = release.get("tag_prefix")
+            if tag_prefix is not None and not isinstance(tag_prefix, str):
+                err(errors, path, "source.release.tag_prefix must be a string")
+
+            checksum_kind_ok = expect_nonempty_str(
+                checksum.get("kind"), "source.checksum.kind", errors, path
+            )
+            checksum_kind = checksum.get("kind") if checksum_kind_ok else None
+            if checksum_kind_ok and checksum_kind not in CHECKSUM_KIND_VALUES:
+                err(
+                    errors,
+                    path,
+                    "source.checksum.kind must be 'download_sha256' or 'shasums256'",
+                )
+            elif checksum_kind == "shasums256":
+                checksum_url_ok = expect_nonempty_str(
+                    checksum.get("url_template"),
+                    "source.checksum.url_template",
+                    errors,
+                    path,
+                )
+                if checksum_url_ok and not str(checksum["url_template"]).startswith("https://"):
+                    err(errors, path, "source.checksum.url_template must start with https://")
+
+            asset_kind_ok = expect_nonempty_str(
+                asset.get("kind"), "source.asset.kind", errors, path
+            )
+            asset_kind = asset.get("kind") if asset_kind_ok else None
+            if asset_kind_ok and asset_kind not in ASSET_KIND_VALUES:
+                err(
+                    errors,
+                    path,
+                    "source.asset.kind must be 'release_asset_url' or 'templated'",
+                )
+            elif asset_kind == "templated":
+                base_url_ok = expect_nonempty_str(
+                    asset.get("base_url"), "source.asset.base_url", errors, path
+                )
+                if base_url_ok and not str(asset["base_url"]).startswith("https://"):
+                    err(errors, path, "source.asset.base_url must start with https://")
+        else:
+            provider_ok = expect_nonempty_str(
+                source.get("provider"), "source.provider", errors, path
+            )
+            provider = source.get("provider") if provider_ok else None
+            if provider == "github":
+                repo_ok = expect_nonempty_str(source.get("repo"), "source.repo", errors, path)
+                if repo_ok and not REPO_RE.fullmatch(str(source["repo"])):
+                    err(errors, path, "source.repo must look like owner/name")
+            elif provider == "nodejs-dist":
+                major = source.get("major")
+                if isinstance(major, bool) or not isinstance(major, int) or major <= 0:
+                    err(errors, path, "source.major must be an integer > 0")
+            elif provider_ok:
+                err(errors, path, "source.provider must be 'github' or 'nodejs-dist'")
+
+            include_prereleases = source.get("include_prereleases")
+            if include_prereleases is not None and not isinstance(
+                include_prereleases, bool
+            ):
+                err(errors, path, "source.include_prereleases must be a boolean")
+
+            tag_prefix = source.get("tag_prefix")
+            if tag_prefix is not None and not isinstance(tag_prefix, str):
+                err(errors, path, "source.tag_prefix must be a string")
 
     if len(path.parts) < 2 or path.parts[-2] != "packages":
         err(errors, path, "package manifest must live under packages/<name>.toml")

--- a/scripts/upstream-release-bot.py
+++ b/scripts/upstream-release-bot.py
@@ -29,6 +29,54 @@ class PlannedUpdate:
         self.release = release
 
 
+def normalize_source(source: dict) -> dict:
+    release = source.get("release")
+    checksum = source.get("checksum")
+    asset = source.get("asset")
+    if isinstance(release, dict) and isinstance(checksum, dict) and isinstance(asset, dict):
+        return {"release": release, "checksum": checksum, "asset": asset}
+
+    provider = source.get("provider")
+    if provider == "github":
+        repo = source.get("repo")
+        if not isinstance(repo, str) or not repo:
+            raise RuntimeError("github source config requires source.repo")
+        normalized_release = {
+            "kind": "github_releases",
+            "repo": repo,
+            "include_prereleases": bool(source.get("include_prereleases", False)),
+        }
+        tag_prefix = source.get("tag_prefix")
+        if isinstance(tag_prefix, str) and tag_prefix:
+            normalized_release["tag_prefix"] = tag_prefix
+        return {
+            "release": normalized_release,
+            "checksum": {"kind": "download_sha256"},
+            "asset": {"kind": "release_asset_url"},
+        }
+
+    if provider == "nodejs-dist":
+        major = source.get("major")
+        if isinstance(major, bool) or not isinstance(major, int) or major <= 0:
+            raise RuntimeError("nodejs-dist source.major must be an integer > 0")
+        return {
+            "release": {
+                "kind": "node_dist_index",
+                "major": major,
+                "include_prereleases": bool(source.get("include_prereleases", False)),
+            },
+            "checksum": {"kind": "shasums256"},
+            "asset": {
+                "kind": "templated",
+                "base_url": f"https://nodejs.org/dist/latest-v{major}.x",
+            },
+        }
+
+    raise RuntimeError(
+        "source config must define either release/checksum/asset tables or a supported legacy provider"
+    )
+
+
 def _load_generator_module(repo_root: Path):
     script_path = repo_root / "scripts" / "registry-generate-manifest.py"
     spec = importlib.util.spec_from_file_location(
@@ -139,11 +187,14 @@ def plan_updates_for_config(
     source = config.get("source", {})
     if not isinstance(source, dict):
         raise RuntimeError(f"source must be a table in {config_path}")
+    normalized = normalize_source(source)
+    release_strategy = normalized["release"]
+    release_kind = release_strategy.get("kind")
 
-    if source.get("provider") == "nodejs-dist":
-        major = source.get("major")
+    if release_kind == "node_dist_index":
+        major = release_strategy.get("major")
         if isinstance(major, bool) or not isinstance(major, int) or major <= 0:
-            raise RuntimeError(f"nodejs-dist source.major must be an integer > 0 in {config_path}")
+            raise RuntimeError(f"node_dist_index release.major must be an integer > 0 in {config_path}")
 
         existing_versions = {
             p.stem for p in (releases_root / package).glob("*.toml") if p.is_file()
@@ -167,10 +218,10 @@ def plan_updates_for_config(
             ]
         return []
 
-    include_prereleases = bool(source.get("include_prereleases", False))
-    tag_prefix = source.get("tag_prefix")
+    include_prereleases = bool(release_strategy.get("include_prereleases", False))
+    tag_prefix = release_strategy.get("tag_prefix")
     if tag_prefix is not None and not isinstance(tag_prefix, str):
-        raise RuntimeError(f"tag_prefix must be a string in {config_path}")
+        raise RuntimeError(f"source.release.tag_prefix must be a string in {config_path}")
 
     existing_versions = {
         p.stem for p in (releases_root / package).glob("*.toml") if p.is_file()
@@ -389,15 +440,17 @@ def main(argv: list[str]) -> int:
         source = config.get("source")
         if not isinstance(source, dict):
             raise RuntimeError(f"Missing source table in {config_path}")
-        if source.get("provider") == "nodejs-dist":
-            major = source.get("major")
+        normalized = normalize_source(source)
+        release_strategy = normalized["release"]
+        if release_strategy.get("kind") == "node_dist_index":
+            major = release_strategy.get("major")
             if isinstance(major, bool) or not isinstance(major, int) or major <= 0:
-                raise RuntimeError(f"Missing or invalid source.major in {config_path}")
+                raise RuntimeError(f"Missing or invalid source.release.major in {config_path}")
             releases = fetch_nodejs_dist_releases(major)
         else:
-            repo = source.get("repo")
+            repo = release_strategy.get("repo")
             if not isinstance(repo, str):
-                raise RuntimeError(f"Missing source.repo in {config_path}")
+                raise RuntimeError(f"Missing source.release.repo in {config_path}")
             releases = fetch_github_releases(repo, token=github_token)
         planned.extend(
             plan_updates_for_config(
@@ -423,11 +476,18 @@ def main(argv: list[str]) -> int:
         config = load_config(update.config_path)
         source = config.get("source")
         shasums_by_name = None
-        if isinstance(source, dict) and source.get("provider") == "nodejs-dist":
-            major = source.get("major")
-            if isinstance(major, bool) or not isinstance(major, int) or major <= 0:
-                raise RuntimeError(f"Missing or invalid source.major in {update.config_path}")
-            shasums_by_name = fetch_nodejs_dist_shasums(major=major)
+        if isinstance(source, dict):
+            normalized = normalize_source(source)
+            release_strategy = normalized["release"]
+            checksum_strategy = normalized["checksum"]
+            if (
+                release_strategy.get("kind") == "node_dist_index"
+                and checksum_strategy.get("kind") == "shasums256"
+            ):
+                major = release_strategy.get("major")
+                if isinstance(major, bool) or not isinstance(major, int) or major <= 0:
+                    raise RuntimeError(f"Missing or invalid source.release.major in {update.config_path}")
+                shasums_by_name = fetch_nodejs_dist_shasums(major=major)
 
         try:
             release_text = generator.generate_release_text(

--- a/tests/test_registry_generate_manifest.py
+++ b/tests/test_registry_generate_manifest.py
@@ -100,9 +100,15 @@ class RegistryGenerateManifestTests(unittest.TestCase):
                     license = "MIT OR Unlicense"
                     homepage = "https://github.com/BurntSushi/ripgrep"
 
-                    [source]
-                    provider = "github"
+                    [source.release]
+                    kind = "github_releases"
                     repo = "BurntSushi/ripgrep"
+
+                    [source.checksum]
+                    kind = "download_sha256"
+
+                    [source.asset]
+                    kind = "release_asset_url"
 
                     [[artifacts]]
                     target = "x86_64-unknown-linux-gnu"
@@ -250,10 +256,18 @@ class RegistryGenerateManifestTests(unittest.TestCase):
                     license = "MIT"
                     homepage = "https://nodejs.org/"
 
-                    [source]
-                    provider = "nodejs-dist"
+                    [source.release]
+                    kind = "node_dist_index"
                     major = 22
                     include_prereleases = false
+
+                    [source.checksum]
+                    kind = "shasums256"
+                    url_template = "https://nodejs.org/dist/latest-v22.x/SHASUMS256.txt"
+
+                    [source.asset]
+                    kind = "templated"
+                    base_url = "https://nodejs.org/dist/latest-v22.x"
 
                     [[artifacts]]
                     target = "x86_64-unknown-linux-gnu"
@@ -326,10 +340,18 @@ class RegistryGenerateManifestTests(unittest.TestCase):
                     license = "MIT"
                     homepage = "https://nodejs.org/"
 
-                    [source]
-                    provider = "nodejs-dist"
+                    [source.release]
+                    kind = "node_dist_index"
                     major = 22
                     include_prereleases = false
+
+                    [source.checksum]
+                    kind = "shasums256"
+                    url_template = "https://nodejs.org/dist/latest-v22.x/SHASUMS256.txt"
+
+                    [source.asset]
+                    kind = "templated"
+                    base_url = "https://nodejs.org/dist/latest-v22.x"
 
                     [[artifacts]]
                     target = "x86_64-unknown-linux-gnu"
@@ -348,8 +370,10 @@ class RegistryGenerateManifestTests(unittest.TestCase):
 
             rendered = self.generator.generate_package_text(config_path=config_path)
 
-            self.assertIn('provider = "nodejs-dist"', rendered)
+            self.assertIn('[source.release]', rendered)
+            self.assertIn('kind = "node_dist_index"', rendered)
             self.assertIn('major = 22', rendered)
+            self.assertIn('[source.asset]', rendered)
             self.assertNotIn('repo =', rendered)
 
 

--- a/tests/test_registry_validate_source.py
+++ b/tests/test_registry_validate_source.py
@@ -78,9 +78,15 @@ class RegistryValidateSourceTests(unittest.TestCase):
                     license = "MIT OR Unlicense"
                     homepage = "https://github.com/BurntSushi/ripgrep"
 
-                    [source]
-                    provider = "github"
+                    [source.release]
+                    kind = "github_releases"
                     repo = "BurntSushi/ripgrep"
+
+                    [source.checksum]
+                    kind = "download_sha256"
+
+                    [source.asset]
+                    kind = "release_asset_url"
 
                     [[artifacts]]
                     target = "x86_64-unknown-linux-gnu"
@@ -145,9 +151,15 @@ class RegistryValidateSourceTests(unittest.TestCase):
                     license = "MIT OR Unlicense"
                     homepage = "https://github.com/BurntSushi/ripgrep"
 
-                    [source]
-                    provider = "github"
+                    [source.release]
+                    kind = "github_releases"
                     repo = "BurntSushi/ripgrep"
+
+                    [source.checksum]
+                    kind = "download_sha256"
+
+                    [source.asset]
+                    kind = "release_asset_url"
 
                     [[artifacts]]
                     target = "x86_64-unknown-linux-gnu"
@@ -184,10 +196,18 @@ class RegistryValidateSourceTests(unittest.TestCase):
                     license = "MIT"
                     homepage = "https://nodejs.org/"
 
-                    [source]
-                    provider = "nodejs-dist"
+                    [source.release]
+                    kind = "node_dist_index"
                     major = 22
                     include_prereleases = false
+
+                    [source.checksum]
+                    kind = "shasums256"
+                    url_template = "https://nodejs.org/dist/latest-v22.x/SHASUMS256.txt"
+
+                    [source.asset]
+                    kind = "templated"
+                    base_url = "https://nodejs.org/dist/latest-v22.x"
 
                     [[artifacts]]
                     target = "x86_64-unknown-linux-gnu"

--- a/tests/test_upstream_release_bot.py
+++ b/tests/test_upstream_release_bot.py
@@ -63,9 +63,15 @@ class UpstreamReleaseBotTests(unittest.TestCase):
                     license = "MIT OR Unlicense"
                     homepage = "https://github.com/BurntSushi/ripgrep"
 
-                    [source]
-                    provider = "github"
+                    [source.release]
+                    kind = "github_releases"
                     repo = "BurntSushi/ripgrep"
+
+                    [source.checksum]
+                    kind = "download_sha256"
+
+                    [source.asset]
+                    kind = "release_asset_url"
                     """
                 ).strip()
                 + "\n",
@@ -113,9 +119,15 @@ class UpstreamReleaseBotTests(unittest.TestCase):
                     license = "MIT OR Unlicense"
                     homepage = "https://github.com/BurntSushi/ripgrep"
 
-                    [source]
-                    provider = "github"
+                    [source.release]
+                    kind = "github_releases"
                     repo = "BurntSushi/ripgrep"
+
+                    [source.checksum]
+                    kind = "download_sha256"
+
+                    [source.asset]
+                    kind = "release_asset_url"
                     """
                 ).strip()
                 + "\n",
@@ -162,10 +174,16 @@ class UpstreamReleaseBotTests(unittest.TestCase):
                     license = "Apache-2.0 OR MIT"
                     homepage = "https://github.com/sharkdp/fd"
 
-                    [source]
-                    provider = "github"
+                    [source.release]
+                    kind = "github_releases"
                     repo = "sharkdp/fd"
                     tag_prefix = "v"
+
+                    [source.checksum]
+                    kind = "download_sha256"
+
+                    [source.asset]
+                    kind = "release_asset_url"
 
                     [[artifacts]]
                     target = "x86_64-apple-darwin"
@@ -315,10 +333,18 @@ class UpstreamReleaseBotTests(unittest.TestCase):
                     license = "MIT"
                     homepage = "https://nodejs.org/"
 
-                    [source]
-                    provider = "nodejs-dist"
+                    [source.release]
+                    kind = "node_dist_index"
                     major = 22
                     include_prereleases = false
+
+                    [source.checksum]
+                    kind = "shasums256"
+                    url_template = "https://nodejs.org/dist/latest-v22.x/SHASUMS256.txt"
+
+                    [source.asset]
+                    kind = "templated"
+                    base_url = "https://nodejs.org/dist/latest-v22.x"
 
                     [[artifacts]]
                     target = "x86_64-unknown-linux-gnu"


### PR DESCRIPTION
## Summary
- rebuild PR 55 onto current `main` so the intervening release and signature commits are no longer part of the diff
- replace provider-only source branching with composed release/checksum/asset strategies
- keep the existing Node package/release manifests from `main`, while migrating representative GitHub and Node source configs to the generalized schema
- update validation, manifest generation, release planning, tests, and README docs for the generalized source model

## Test Plan
- `python3 scripts/registry-validate-source.py registry/sources/fd.toml registry/sources/node.toml`
- `python3 scripts/registry-validate.py --allow-missing-signatures packages/node.toml releases/node/22.22.2.toml`
- `python3 -m unittest tests.test_registry_validate_source tests.test_registry_generate_manifest tests.test_upstream_release_bot -v`
- `python3 -m unittest discover tests -v`
- `python3 scripts/registry-validate-source.py registry/sources/*.toml`
- `python3 scripts/registry-validate.py --allow-missing-signatures packages/*.toml releases/*/*.toml`

Closes #72