### PR TITLE
feat(registry): add zoxide package

### DIFF
--- a/packages/zoxide.toml
+++ b/packages/zoxide.toml
@@ -1,0 +1,165 @@
+name = "zoxide"
+license = "MIT"
+homepage = "https://github.com/ajeetdsouza/zoxide"
+
+[source]
+provider = "github"
+repo = "ajeetdsouza/zoxide"
+tag_prefix = "v"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "zoxide-{version}-x86_64-unknown-linux-musl.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "zoxide"
+path = "zoxide"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completions/zoxide.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completions/_zoxide"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completions/zoxide.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completions/_zoxide.ps1"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "zoxide-{version}-aarch64-unknown-linux-musl.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "zoxide"
+path = "zoxide"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completions/zoxide.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completions/_zoxide"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completions/zoxide.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completions/_zoxide.ps1"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "zoxide-{version}-x86_64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "zoxide"
+path = "zoxide"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completions/zoxide.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completions/_zoxide"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completions/zoxide.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completions/_zoxide.ps1"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "zoxide-{version}-aarch64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "zoxide"
+path = "zoxide"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completions/zoxide.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completions/_zoxide"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completions/zoxide.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completions/_zoxide.ps1"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "zoxide-{version}-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "zoxide"
+path = "zoxide.exe"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completions/zoxide.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completions/_zoxide"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completions/zoxide.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completions/_zoxide.ps1"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "zoxide-{version}-aarch64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "zoxide"
+path = "zoxide.exe"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completions/zoxide.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completions/_zoxide"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completions/zoxide.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completions/_zoxide.ps1"

--- a/registry/sources/zoxide.toml
+++ b/registry/sources/zoxide.toml
@@ -1,0 +1,165 @@
+name = "zoxide"
+license = "MIT"
+homepage = "https://github.com/ajeetdsouza/zoxide"
+
+[source]
+provider = "github"
+repo = "ajeetdsouza/zoxide"
+tag_prefix = "v"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "zoxide-{version}-x86_64-unknown-linux-musl.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "zoxide"
+path = "zoxide"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completions/zoxide.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completions/_zoxide"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completions/zoxide.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completions/_zoxide.ps1"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "zoxide-{version}-aarch64-unknown-linux-musl.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "zoxide"
+path = "zoxide"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completions/zoxide.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completions/_zoxide"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completions/zoxide.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completions/_zoxide.ps1"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "zoxide-{version}-x86_64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "zoxide"
+path = "zoxide"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completions/zoxide.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completions/_zoxide"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completions/zoxide.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completions/_zoxide.ps1"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "zoxide-{version}-aarch64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "zoxide"
+path = "zoxide"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completions/zoxide.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completions/_zoxide"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completions/zoxide.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completions/_zoxide.ps1"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "zoxide-{version}-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "zoxide"
+path = "zoxide.exe"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completions/zoxide.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completions/_zoxide"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completions/zoxide.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completions/_zoxide.ps1"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "zoxide-{version}-aarch64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "zoxide"
+path = "zoxide.exe"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completions/zoxide.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completions/_zoxide"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completions/zoxide.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completions/_zoxide.ps1"

--- a/releases/zoxide/0.9.9.toml
+++ b/releases/zoxide/0.9.9.toml
@@ -1,0 +1,32 @@
+name = "zoxide"
+version = "0.9.9"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/ajeetdsouza/zoxide/releases/download/v0.9.9/zoxide-0.9.9-x86_64-unknown-linux-musl.tar.gz"
+sha256 = "4ff057d3c4d957946937274c2b8be7af2a9bbae7f90a1b5e9baaa7cb65a20caa"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/ajeetdsouza/zoxide/releases/download/v0.9.9/zoxide-0.9.9-aarch64-unknown-linux-musl.tar.gz"
+sha256 = "96e6ea2e47a71db42cb7ad5a36e9209c8cb3708f8ae00f6945573d0d93315cb0"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/ajeetdsouza/zoxide/releases/download/v0.9.9/zoxide-0.9.9-x86_64-apple-darwin.tar.gz"
+sha256 = "364249cff18354397c72ebb6b8f7358404c051c486e0f2f7a46e36c86c16f8c7"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/ajeetdsouza/zoxide/releases/download/v0.9.9/zoxide-0.9.9-aarch64-apple-darwin.tar.gz"
+sha256 = "57e733d0436309dae2ed97e46bba43937209395298e1d88812d4e893900cb40a"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/ajeetdsouza/zoxide/releases/download/v0.9.9/zoxide-0.9.9-x86_64-pc-windows-msvc.zip"
+sha256 = "5af00d0916f05631e3030537289eac56605e7c1733318c4d525c8e847f12496d"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+url = "https://github.com/ajeetdsouza/zoxide/releases/download/v0.9.9/zoxide-0.9.9-aarch64-pc-windows-msvc.zip"
+sha256 = "58c55ef6f0ead099fbb31ed69566118d7c7c7a4e16c858bbdb4f7def40cd534b"

--- a/tests/test_registry_generate_manifest.py
+++ b/tests/test_registry_generate_manifest.py
@@ -25,6 +25,68 @@ class RegistryGenerateManifestTests(unittest.TestCase):
     def setUp(self) -> None:
         self.generator = load_module()
 
+    def test_generates_zoxide_release_manifest_with_downloaded_sha(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="manifest-gen-") as tmp:
+            tmp_path = Path(tmp)
+            config_path = tmp_path / "zoxide.toml"
+            config_path.write_text(
+                textwrap.dedent(
+                    """
+                    name = "zoxide"
+                    license = "MIT"
+                    homepage = "https://github.com/ajeetdsouza/zoxide"
+
+                    [source]
+                    provider = "github"
+                    repo = "ajeetdsouza/zoxide"
+                    tag_prefix = "v"
+
+                    [[artifacts]]
+                    target = "x86_64-unknown-linux-gnu"
+                    asset = "zoxide-{version}-x86_64-unknown-linux-musl.tar.gz"
+                    archive = "tar.gz"
+                    strip_components = 0
+
+                    [[artifacts.binaries]]
+                    name = "zoxide"
+                    path = "zoxide"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            release = {
+                "tag_name": "v0.9.9",
+                "assets": [
+                    {
+                        "name": "zoxide-0.9.9-x86_64-unknown-linux-musl.tar.gz",
+                        "browser_download_url": "https://example.invalid/zoxide.tar.gz",
+                    }
+                ],
+            }
+
+            payload = b"zoxide-linux-payload"
+            expected_sha = hashlib.sha256(payload).hexdigest()
+
+            def fake_download(_url: str, dest: Path) -> None:
+                dest.write_bytes(payload)
+
+            rendered = self.generator.generate_release_text(
+                config_path=config_path,
+                version="0.9.9",
+                release=release,
+                downloader=fake_download,
+            )
+
+            self.assertIn('name = "zoxide"', rendered)
+            self.assertIn('version = "0.9.9"', rendered)
+            self.assertIn(
+                'url = "https://example.invalid/zoxide.tar.gz"',
+                rendered,
+            )
+            self.assertIn(f'sha256 = "{expected_sha}"', rendered)
+
     def test_generates_release_manifest_with_downloaded_sha(self) -> None:
         with tempfile.TemporaryDirectory(prefix="manifest-gen-") as tmp:
             tmp_path = Path(tmp)

--- a/tests/test_registry_validate_source.py
+++ b/tests/test_registry_validate_source.py
@@ -10,6 +10,51 @@ SCRIPT = REPO_ROOT / "scripts" / "registry-validate-source.py"
 
 
 class RegistryValidateSourceTests(unittest.TestCase):
+    def test_valid_zoxide_style_source_config_passes(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="source-config-") as tmp:
+            config = Path(tmp) / "zoxide.toml"
+            config.write_text(
+                textwrap.dedent(
+                    """
+                    name = "zoxide"
+                    license = "MIT"
+                    homepage = "https://github.com/ajeetdsouza/zoxide"
+
+                    [source]
+                    provider = "github"
+                    repo = "ajeetdsouza/zoxide"
+                    tag_prefix = "v"
+                    include_prereleases = false
+
+                    [[artifacts]]
+                    target = "x86_64-unknown-linux-gnu"
+                    asset = "zoxide-{version}-x86_64-unknown-linux-musl.tar.gz"
+                    archive = "tar.gz"
+                    strip_components = 0
+
+                    [[artifacts.binaries]]
+                    name = "zoxide"
+                    path = "zoxide"
+
+                    [[artifacts.completions]]
+                    shell = "bash"
+                    path = "completions/zoxide.bash"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                ["python3", str(SCRIPT), str(config)],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+            )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("Validation passed", result.stdout)
+
     def test_every_packaged_package_has_source_config(self) -> None:
         packages_root = REPO_ROOT / "packages"
         sources_root = REPO_ROOT / "registry" / "sources"


### PR DESCRIPTION
## Summary
- add  as an official Crosspack registry package
- include source and release manifests for zoxide 0.9.9 across linux, macOS, and Windows targets
- add focused regression tests covering zoxide-style source config and manifest generation

## Validation
- Validation passed: 1 source config(s)
- Validated 2 manifest(s): package/release schema and checksum checks passed.
- 

Closes SPI-84