### PR TITLE
fix(bot): retry transient artifact downloads

### DIFF
--- a/scripts/registry-generate-manifest.py
+++ b/scripts/registry-generate-manifest.py
@@ -6,6 +6,8 @@ import hashlib
 import json
 import re
 import tempfile
+import time
+import urllib.error
 import urllib.request
 from pathlib import Path
 
@@ -19,7 +21,12 @@ class GenerateError(Exception):
     pass
 
 
+class DownloadError(Exception):
+    pass
+
+
 NODE_DIST_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+DOWNLOAD_ATTEMPTS = 3
 
 
 def _escape(value: str) -> str:
@@ -118,15 +125,40 @@ def render_release_text(doc: dict) -> str:
 
 
 def download(url: str, dest: Path) -> None:
-    req = urllib.request.Request(
-        url,
-        headers={
-            "Accept": "application/octet-stream",
-            "User-Agent": "crosspack-registry-upstream-bot",
-        },
-    )
-    with urllib.request.urlopen(req, timeout=30) as response:  # noqa: S310
-        dest.write_bytes(response.read())
+    last_error: Exception | None = None
+    for attempt in range(DOWNLOAD_ATTEMPTS):
+        req = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/octet-stream",
+                "User-Agent": "crosspack-registry-upstream-bot",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=30) as response:  # noqa: S310
+                dest.write_bytes(response.read())
+            return
+        except urllib.error.HTTPError as error:
+            if error.code < 500:
+                raise DownloadError(
+                    f"failed to download {url}: HTTP {error.code} {error.reason}"
+                ) from error
+            last_error = error
+        except urllib.error.URLError as error:
+            last_error = error
+
+        if attempt < DOWNLOAD_ATTEMPTS - 1:
+            time.sleep(2**attempt)
+
+    if isinstance(last_error, urllib.error.HTTPError):
+        raise DownloadError(
+            "failed to download "
+            f"{url} after {DOWNLOAD_ATTEMPTS} attempts: "
+            f"HTTP {last_error.code} {last_error.reason}"
+        ) from last_error
+    raise DownloadError(
+        f"failed to download {url} after {DOWNLOAD_ATTEMPTS} attempts: {last_error}"
+    ) from last_error
 
 
 def sha256_file(path: Path) -> str:

--- a/tests/test_registry_generate_manifest.py
+++ b/tests/test_registry_generate_manifest.py
@@ -3,7 +3,9 @@ import importlib.util
 import tempfile
 import textwrap
 import unittest
+import urllib.error
 from pathlib import Path
+from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -87,6 +89,93 @@ class RegistryGenerateManifestTests(unittest.TestCase):
             self.assertIn(f'sha256 = "{expected_sha}"', rendered)
             self.assertNotIn("license =", rendered)
             self.assertNotIn("homepage =", rendered)
+
+    def test_download_retries_transient_http_error(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="manifest-gen-") as tmp:
+            dest = Path(tmp) / "artifact.tar.gz"
+            payload = b"artifact-payload"
+            failures = [
+                urllib.error.HTTPError(
+                    "https://example.invalid/artifact.tar.gz",
+                    502,
+                    "Bad Gateway",
+                    hdrs=None,
+                    fp=None,
+                )
+            ]
+
+            class FakeResponse:
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, _exc_type, _exc, _traceback):
+                    return False
+
+                def read(self) -> bytes:
+                    return payload
+
+            def fake_urlopen(_req, timeout: int):
+                self.assertEqual(timeout, 30)
+                if failures:
+                    raise failures.pop()
+                return FakeResponse()
+
+            with mock.patch.object(
+                self.generator.urllib.request, "urlopen", side_effect=fake_urlopen
+            ) as urlopen, mock.patch.object(self.generator.time, "sleep") as sleep:
+                self.generator.download("https://example.invalid/artifact.tar.gz", dest)
+
+            self.assertEqual(dest.read_bytes(), payload)
+            self.assertEqual(urlopen.call_count, 2)
+            sleep.assert_called_once_with(1)
+
+    def test_download_fails_fast_for_non_transient_http_error(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="manifest-gen-") as tmp:
+            dest = Path(tmp) / "artifact.tar.gz"
+            error = urllib.error.HTTPError(
+                "https://example.invalid/missing.tar.gz",
+                404,
+                "Not Found",
+                hdrs=None,
+                fp=None,
+            )
+
+            with mock.patch.object(
+                self.generator.urllib.request, "urlopen", side_effect=error
+            ) as urlopen, mock.patch.object(self.generator.time, "sleep") as sleep:
+                with self.assertRaisesRegex(
+                    self.generator.DownloadError,
+                    "https://example.invalid/missing.tar.gz.*HTTP 404 Not Found",
+                ):
+                    self.generator.download("https://example.invalid/missing.tar.gz", dest)
+
+            self.assertFalse(dest.exists())
+            self.assertEqual(urlopen.call_count, 1)
+            sleep.assert_not_called()
+
+    def test_download_reports_url_after_exhausting_transient_errors(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="manifest-gen-") as tmp:
+            dest = Path(tmp) / "artifact.tar.gz"
+            error = urllib.error.HTTPError(
+                "https://example.invalid/flaky.tar.gz",
+                502,
+                "Bad Gateway",
+                hdrs=None,
+                fp=None,
+            )
+
+            with mock.patch.object(
+                self.generator.urllib.request, "urlopen", side_effect=error
+            ) as urlopen, mock.patch.object(self.generator.time, "sleep") as sleep:
+                with self.assertRaisesRegex(
+                    self.generator.DownloadError,
+                    "https://example.invalid/flaky.tar.gz.*3 attempts.*HTTP 502 Bad Gateway",
+                ):
+                    self.generator.download("https://example.invalid/flaky.tar.gz", dest)
+
+            self.assertFalse(dest.exists())
+            self.assertEqual(urlopen.call_count, 3)
+            self.assertEqual([call.args for call in sleep.call_args_list], [(1,), (2,)])
 
     def test_generates_nodejs_dist_release_manifest_from_shasums(self) -> None:
         with tempfile.TemporaryDirectory(prefix="manifest-gen-") as tmp:


### PR DESCRIPTION
## Summary
- Retry transient HTTP 5xx and URL errors when downloading upstream release assets for manifest generation.
- Fail fast on non-transient HTTP errors and include URL/status details when retries are exhausted.
- Add tests covering successful retry, non-transient failure, and exhausted transient retries.

## Verification
- `python3 -m unittest tests/test_registry_generate_manifest.py`
- `python3 -m unittest discover -s tests` *(fails in this environment because `xxd` is missing for `test_sign_changed_manifests.py`; unrelated to this change)*