### PR TITLE
fix(signatures): sign missing sidecars

### DIFF
--- a/scripts/sign-changed-manifests.sh
+++ b/scripts/sign-changed-manifests.sh
@@ -9,8 +9,8 @@ if ! command -v openssl >/dev/null 2>&1; then
   echo "openssl is required" >&2
   exit 1
 fi
-if ! command -v xxd >/dev/null 2>&1; then
-  echo "xxd is required" >&2
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required" >&2
   exit 1
 fi
 
@@ -22,13 +22,17 @@ if [ -z "${BEFORE_SHA}" ] || [ "${BEFORE_SHA}" = "000000000000000000000000000000
   fi
 fi
 
-mapfile -t changed_manifests < <(
+mapfile -t changed_manifests < <({
   git diff --name-only "${BEFORE_SHA}" "${AFTER_SHA}" -- 'packages/*.toml' 'packages/*.toml.sig' 'releases/**/*.toml' 'releases/**/*.toml.sig' \
     | while IFS= read -r file; do
         manifest_path="${file%.sig}"
         [ -f "$manifest_path" ] && printf '%s\n' "$manifest_path"
-      done | sort -u
-)
+      done
+  find packages releases -type f -name '*.toml' ! -name '*.toml.sig' \
+    | while IFS= read -r manifest_path; do
+        [ -f "${manifest_path}.sig" ] || printf '%s\n' "$manifest_path"
+      done
+} | sort -u)
 
 if [ "${#changed_manifests[@]}" -eq 0 ]; then
   echo "no changed manifest files detected"
@@ -43,7 +47,7 @@ chmod 600 "$key_file"
 for manifest in "${changed_manifests[@]}"; do
   sig_bin="$(mktemp)"
   openssl pkeyutl -sign -rawin -inkey "$key_file" -in "$manifest" -out "$sig_bin"
-  xxd -p -c 9999 "$sig_bin" | tr -d '\n' > "${manifest}.sig"
+  python3 -c 'import pathlib, sys; sys.stdout.write(pathlib.Path(sys.argv[1]).read_bytes().hex())' "$sig_bin" > "${manifest}.sig"
   printf '\n' >> "${manifest}.sig"
   rm -f "$sig_bin"
   echo "signed ${manifest}"

--- a/tests/test_sign_changed_manifests.py
+++ b/tests/test_sign_changed_manifests.py
@@ -32,6 +32,14 @@ class SignChangedManifestsTests(unittest.TestCase):
         )
         self.signature_path = self.manifest_path.with_suffix(".toml.sig")
 
+        self.missing_manifest_path = self.repo_root / "packages" / "node.toml"
+        self.missing_manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        self.missing_manifest_path.write_text(
+            """name = \"node\"\nlicense = \"MIT\"\nhomepage = \"https://nodejs.org/\"\n""",
+            encoding="utf-8",
+        )
+        self.missing_signature_path = self.missing_manifest_path.with_suffix(".toml.sig")
+
         self.key_path = self.repo_root / "signing-key.pem"
         subprocess.run(
             ["openssl", "genpkey", "-algorithm", "ed25519", "-out", str(self.key_path)],
@@ -125,6 +133,30 @@ class SignChangedManifestsTests(unittest.TestCase):
             "expected deleted sidecar to be regenerated for changed manifest",
         )
         self.assertIn("signed releases/demo/1.0.0.toml", result.stdout)
+
+    def test_signs_manifest_with_missing_sidecar_outside_changed_range(self) -> None:
+        env = {
+            **os.environ,
+            "SIGNING_PRIVATE_KEY_PEM": self.key_path.read_text(encoding="utf-8"),
+            "BEFORE_SHA": self.before_sha,
+            "AFTER_SHA": self.after_sha,
+            "LC_ALL": "C",
+        }
+
+        result = subprocess.run(
+            [str(self.script_path)],
+            cwd=self.repo_root,
+            text=True,
+            capture_output=True,
+            env=env,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertTrue(
+            self.missing_signature_path.exists(),
+            "expected missing sidecar to be generated even when manifest was unchanged",
+        )
+        self.assertIn("signed packages/node.toml", result.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Include manifests with missing `.sig` sidecars when signing manifests on merge, even if the manifest itself did not change in the current push range.
- Replace the `xxd` dependency with Python hex encoding so local and CI signing tests do not require an extra binary.
- Add coverage for signing an unchanged manifest whose sidecar is missing.

## Verification
- `bash -n scripts/sign-changed-manifests.sh`
- `python3 -m unittest tests/test_sign_changed_manifests.py`
- `python3 -m unittest tests/test_registry_generate_manifest.py`
- `python3 -m unittest discover -s tests`

## Context
Main is currently failing full registry validation because `packages/node.toml` and `releases/node/22.22.2.toml` exist without matching signature sidecars. The signing workflow ran successfully, but the script only considered manifests changed in the push range, so it did not repair those missing sidecars.