### PR TITLE
fix(ci): run registry gate after signing

### DIFF
--- a/.github/workflows/registry-quality-gate.yml
+++ b/.github/workflows/registry-quality-gate.yml
@@ -9,7 +9,11 @@ on:
       - 'releases/**/*.toml.sig'
       - 'scripts/**'
       - '.github/workflows/registry-quality-gate.yml'
-  push:
+  workflow_run:
+    workflows:
+      - Sign Manifests On Merge
+    types:
+      - completed
     branches:
       - main
   workflow_dispatch:

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -1,0 +1,22 @@
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class GitHubWorkflowTests(unittest.TestCase):
+    def test_registry_quality_gate_full_scan_runs_after_signing_workflow(self) -> None:
+        quality_gate = (
+            REPO_ROOT / ".github" / "workflows" / "registry-quality-gate.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertNotIn("\n  push:", quality_gate)
+        self.assertIn("\n  workflow_run:", quality_gate)
+        self.assertIn("      - Sign Manifests On Merge", quality_gate)
+        self.assertIn("      - completed", quality_gate)
+        self.assertIn("      - main", quality_gate)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Run the full registry quality gate after the signing workflow completes on `main` instead of racing it on the same `push` event.
- Keep PR validation behavior intact while avoiding missing-signature failures before generated sidecars are committed.
- Add a workflow regression test that guards against reintroducing the push-based race.

## Verification
- `python3 -m unittest tests.test_github_workflows`
- `python3 -m unittest discover tests`