### PR TITLE
chore(registry): add curated CLI tools

### DIFF
--- a/packages/bottom.toml
+++ b/packages/bottom.toml
@@ -1,0 +1,138 @@
+name = "bottom"
+license = "MIT"
+homepage = "https://github.com/ClementTsang/bottom"
+
+[source]
+provider = "github"
+repo = "ClementTsang/bottom"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "bottom_x86_64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "btm"
+path = "btm"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completion/btm.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completion/_btm"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completion/btm.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completion/_btm.ps1"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "bottom_aarch64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "btm"
+path = "btm"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completion/btm.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completion/_btm"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completion/btm.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completion/_btm.ps1"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "bottom_x86_64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "btm"
+path = "btm"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completion/btm.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completion/_btm"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completion/btm.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completion/_btm.ps1"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "bottom_aarch64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "btm"
+path = "btm"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completion/btm.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completion/_btm"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completion/btm.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completion/_btm.ps1"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "bottom_x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "btm"
+path = "btm.exe"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completion/btm.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completion/_btm"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completion/btm.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completion/_btm.ps1"

--- a/packages/direnv.toml
+++ b/packages/direnv.toml
@@ -1,0 +1,59 @@
+name = "direnv"
+license = "MIT"
+homepage = "https://github.com/direnv/direnv"
+
+[source]
+provider = "github"
+repo = "direnv/direnv"
+tag_prefix = "v"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "direnv.linux-amd64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "direnv"
+path = "direnv"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "direnv.linux-arm64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "direnv"
+path = "direnv"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "direnv.darwin-amd64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "direnv"
+path = "direnv"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "direnv.darwin-arm64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "direnv"
+path = "direnv"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "direnv.windows-amd64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "direnv"
+path = "direnv.exe"

--- a/packages/eza.toml
+++ b/packages/eza.toml
@@ -1,0 +1,39 @@
+name = "eza"
+license = "MIT"
+homepage = "https://github.com/eza-community/eza"
+
+[source]
+provider = "github"
+repo = "eza-community/eza"
+tag_prefix = "v"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "eza_x86_64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "eza"
+path = "eza"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "eza_aarch64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "eza"
+path = "eza"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "eza.exe_x86_64-pc-windows-gnu.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "eza"
+path = "eza.exe"

--- a/packages/hyperfine.toml
+++ b/packages/hyperfine.toml
@@ -1,0 +1,139 @@
+name = "hyperfine"
+license = "Apache-2.0 OR MIT"
+homepage = "https://github.com/sharkdp/hyperfine"
+
+[source]
+provider = "github"
+repo = "sharkdp/hyperfine"
+tag_prefix = "v"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "hyperfine-v{version}-x86_64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "hyperfine"
+path = "hyperfine"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "autocomplete/hyperfine.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "autocomplete/_hyperfine"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "autocomplete/hyperfine.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "autocomplete/_hyperfine.ps1"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "hyperfine-v{version}-aarch64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "hyperfine"
+path = "hyperfine"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "autocomplete/hyperfine.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "autocomplete/_hyperfine"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "autocomplete/hyperfine.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "autocomplete/_hyperfine.ps1"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "hyperfine-v{version}-x86_64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "hyperfine"
+path = "hyperfine"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "autocomplete/hyperfine.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "autocomplete/_hyperfine"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "autocomplete/hyperfine.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "autocomplete/_hyperfine.ps1"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "hyperfine-v{version}-aarch64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "hyperfine"
+path = "hyperfine"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "autocomplete/hyperfine.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "autocomplete/_hyperfine"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "autocomplete/hyperfine.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "autocomplete/_hyperfine.ps1"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "hyperfine-v{version}-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "hyperfine"
+path = "hyperfine.exe"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "autocomplete/hyperfine.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "autocomplete/_hyperfine"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "autocomplete/hyperfine.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "autocomplete/_hyperfine.ps1"

--- a/packages/sd.toml
+++ b/packages/sd.toml
@@ -1,0 +1,139 @@
+name = "sd"
+license = "MIT"
+homepage = "https://github.com/chmln/sd"
+
+[source]
+provider = "github"
+repo = "chmln/sd"
+tag_prefix = "v"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "sd-v{version}-x86_64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "sd"
+path = "sd"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completions/sd.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completions/_sd"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completions/sd.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completions/_sd.ps1"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "sd-v{version}-aarch64-unknown-linux-musl.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "sd"
+path = "sd"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completions/sd.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completions/_sd"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completions/sd.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completions/_sd.ps1"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "sd-v{version}-x86_64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "sd"
+path = "sd"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completions/sd.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completions/_sd"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completions/sd.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completions/_sd.ps1"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "sd-v{version}-aarch64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "sd"
+path = "sd"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completions/sd.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completions/_sd"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completions/sd.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completions/_sd.ps1"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "sd-v{version}-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "sd"
+path = "sd.exe"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completions/sd.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completions/_sd"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completions/sd.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completions/_sd.ps1"

--- a/packages/yq.toml
+++ b/packages/yq.toml
@@ -1,0 +1,59 @@
+name = "yq"
+license = "MIT"
+homepage = "https://github.com/mikefarah/yq"
+
+[source]
+provider = "github"
+repo = "mikefarah/yq"
+tag_prefix = "v"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "yq_linux_amd64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "yq"
+path = "yq_linux_amd64"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "yq_linux_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "yq"
+path = "yq_linux_arm64"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "yq_darwin_amd64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "yq"
+path = "yq_darwin_amd64"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "yq_darwin_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "yq"
+path = "yq_darwin_arm64"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "yq_windows_amd64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "yq"
+path = "yq_windows_amd64.exe"

--- a/packages/zellij.toml
+++ b/packages/zellij.toml
@@ -1,0 +1,59 @@
+name = "zellij"
+license = "MIT"
+homepage = "https://github.com/zellij-org/zellij"
+
+[source]
+provider = "github"
+repo = "zellij-org/zellij"
+tag_prefix = "v"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "zellij-x86_64-unknown-linux-musl.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "zellij"
+path = "zellij"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "zellij-aarch64-unknown-linux-musl.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "zellij"
+path = "zellij"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "zellij-x86_64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "zellij"
+path = "zellij"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "zellij-aarch64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "zellij"
+path = "zellij"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "zellij-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "zellij"
+path = "zellij.exe"

--- a/registry/sources/bottom.toml
+++ b/registry/sources/bottom.toml
@@ -1,0 +1,138 @@
+name = "bottom"
+license = "MIT"
+homepage = "https://github.com/ClementTsang/bottom"
+
+[source]
+provider = "github"
+repo = "ClementTsang/bottom"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "bottom_x86_64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "btm"
+path = "btm"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completion/btm.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completion/_btm"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completion/btm.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completion/_btm.ps1"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "bottom_aarch64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "btm"
+path = "btm"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completion/btm.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completion/_btm"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completion/btm.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completion/_btm.ps1"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "bottom_x86_64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "btm"
+path = "btm"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completion/btm.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completion/_btm"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completion/btm.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completion/_btm.ps1"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "bottom_aarch64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "btm"
+path = "btm"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completion/btm.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completion/_btm"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completion/btm.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completion/_btm.ps1"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "bottom_x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "btm"
+path = "btm.exe"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completion/btm.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completion/_btm"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completion/btm.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completion/_btm.ps1"

--- a/registry/sources/direnv.toml
+++ b/registry/sources/direnv.toml
@@ -1,0 +1,59 @@
+name = "direnv"
+license = "MIT"
+homepage = "https://github.com/direnv/direnv"
+
+[source]
+provider = "github"
+repo = "direnv/direnv"
+tag_prefix = "v"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "direnv.linux-amd64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "direnv"
+path = "direnv"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "direnv.linux-arm64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "direnv"
+path = "direnv"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "direnv.darwin-amd64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "direnv"
+path = "direnv"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "direnv.darwin-arm64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "direnv"
+path = "direnv"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "direnv.windows-amd64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "direnv"
+path = "direnv.exe"

--- a/registry/sources/eza.toml
+++ b/registry/sources/eza.toml
@@ -1,0 +1,39 @@
+name = "eza"
+license = "MIT"
+homepage = "https://github.com/eza-community/eza"
+
+[source]
+provider = "github"
+repo = "eza-community/eza"
+tag_prefix = "v"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "eza_x86_64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "eza"
+path = "eza"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "eza_aarch64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "eza"
+path = "eza"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "eza.exe_x86_64-pc-windows-gnu.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "eza"
+path = "eza.exe"

--- a/registry/sources/hyperfine.toml
+++ b/registry/sources/hyperfine.toml
@@ -1,0 +1,139 @@
+name = "hyperfine"
+license = "Apache-2.0 OR MIT"
+homepage = "https://github.com/sharkdp/hyperfine"
+
+[source]
+provider = "github"
+repo = "sharkdp/hyperfine"
+tag_prefix = "v"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "hyperfine-v{version}-x86_64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "hyperfine"
+path = "hyperfine"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "autocomplete/hyperfine.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "autocomplete/_hyperfine"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "autocomplete/hyperfine.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "autocomplete/_hyperfine.ps1"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "hyperfine-v{version}-aarch64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "hyperfine"
+path = "hyperfine"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "autocomplete/hyperfine.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "autocomplete/_hyperfine"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "autocomplete/hyperfine.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "autocomplete/_hyperfine.ps1"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "hyperfine-v{version}-x86_64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "hyperfine"
+path = "hyperfine"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "autocomplete/hyperfine.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "autocomplete/_hyperfine"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "autocomplete/hyperfine.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "autocomplete/_hyperfine.ps1"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "hyperfine-v{version}-aarch64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "hyperfine"
+path = "hyperfine"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "autocomplete/hyperfine.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "autocomplete/_hyperfine"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "autocomplete/hyperfine.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "autocomplete/_hyperfine.ps1"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "hyperfine-v{version}-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "hyperfine"
+path = "hyperfine.exe"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "autocomplete/hyperfine.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "autocomplete/_hyperfine"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "autocomplete/hyperfine.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "autocomplete/_hyperfine.ps1"

--- a/registry/sources/sd.toml
+++ b/registry/sources/sd.toml
@@ -1,0 +1,139 @@
+name = "sd"
+license = "MIT"
+homepage = "https://github.com/chmln/sd"
+
+[source]
+provider = "github"
+repo = "chmln/sd"
+tag_prefix = "v"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "sd-v{version}-x86_64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "sd"
+path = "sd"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completions/sd.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completions/_sd"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completions/sd.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completions/_sd.ps1"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "sd-v{version}-aarch64-unknown-linux-musl.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "sd"
+path = "sd"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completions/sd.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completions/_sd"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completions/sd.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completions/_sd.ps1"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "sd-v{version}-x86_64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "sd"
+path = "sd"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completions/sd.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completions/_sd"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completions/sd.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completions/_sd.ps1"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "sd-v{version}-aarch64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "sd"
+path = "sd"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completions/sd.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completions/_sd"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completions/sd.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completions/_sd.ps1"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "sd-v{version}-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "sd"
+path = "sd.exe"
+
+[[artifacts.completions]]
+shell = "bash"
+path = "completions/sd.bash"
+
+[[artifacts.completions]]
+shell = "zsh"
+path = "completions/_sd"
+
+[[artifacts.completions]]
+shell = "fish"
+path = "completions/sd.fish"
+
+[[artifacts.completions]]
+shell = "powershell"
+path = "completions/_sd.ps1"

--- a/registry/sources/yq.toml
+++ b/registry/sources/yq.toml
@@ -1,0 +1,59 @@
+name = "yq"
+license = "MIT"
+homepage = "https://github.com/mikefarah/yq"
+
+[source]
+provider = "github"
+repo = "mikefarah/yq"
+tag_prefix = "v"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "yq_linux_amd64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "yq"
+path = "yq_linux_amd64"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "yq_linux_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "yq"
+path = "yq_linux_arm64"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "yq_darwin_amd64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "yq"
+path = "yq_darwin_amd64"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "yq_darwin_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "yq"
+path = "yq_darwin_arm64"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "yq_windows_amd64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "yq"
+path = "yq_windows_amd64.exe"

--- a/registry/sources/zellij.toml
+++ b/registry/sources/zellij.toml
@@ -1,0 +1,59 @@
+name = "zellij"
+license = "MIT"
+homepage = "https://github.com/zellij-org/zellij"
+
+[source]
+provider = "github"
+repo = "zellij-org/zellij"
+tag_prefix = "v"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "zellij-x86_64-unknown-linux-musl.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "zellij"
+path = "zellij"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "zellij-aarch64-unknown-linux-musl.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "zellij"
+path = "zellij"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "zellij-x86_64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "zellij"
+path = "zellij"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "zellij-aarch64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "zellij"
+path = "zellij"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "zellij-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "zellij"
+path = "zellij.exe"

--- a/releases/bottom/0.12.3.toml
+++ b/releases/bottom/0.12.3.toml
@@ -1,0 +1,27 @@
+name = "bottom"
+version = "0.12.3"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/ClementTsang/bottom/releases/download/0.12.3/bottom_x86_64-unknown-linux-gnu.tar.gz"
+sha256 = "468131d586dee6f4cce23fae597646cfd032103ecf749a478acb9d236adab6d6"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/ClementTsang/bottom/releases/download/0.12.3/bottom_aarch64-unknown-linux-gnu.tar.gz"
+sha256 = "5138f2fab99e267073ad542de0e3da85af842761e8083127161073d4a8ef25b2"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/ClementTsang/bottom/releases/download/0.12.3/bottom_x86_64-apple-darwin.tar.gz"
+sha256 = "5744b5c78db14b85e025c31ded93ba038041e6ff2e8c16ea1d2f9bdb6487316f"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/ClementTsang/bottom/releases/download/0.12.3/bottom_aarch64-apple-darwin.tar.gz"
+sha256 = "106e9493d20192d18dbe46d4c99f680d817c796724103ee258567070fcd16429"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/ClementTsang/bottom/releases/download/0.12.3/bottom_x86_64-pc-windows-msvc.zip"
+sha256 = "567879fd7210f8a692cd2657b41eda43c7713bef74dd025b240247accdda14fb"

--- a/releases/direnv/2.37.1.toml
+++ b/releases/direnv/2.37.1.toml
@@ -1,0 +1,27 @@
+name = "direnv"
+version = "2.37.1"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/direnv/direnv/releases/download/v2.37.1/direnv.linux-amd64"
+sha256 = "1f1b93dd6f38523fde26dfac96151ef9d31a374e3005cd3345fb93555ae0c9b5"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/direnv/direnv/releases/download/v2.37.1/direnv.linux-arm64"
+sha256 = "2a9cef8d73521d6a3ec3f2871c4b747b8c4cc038628c1b57a7efa42b393a2d82"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/direnv/direnv/releases/download/v2.37.1/direnv.darwin-amd64"
+sha256 = "24fb9ce48b563d7e9fbdd3a4e3e836941654a31ce3e67eba9eaafc3dcd8ae73b"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/direnv/direnv/releases/download/v2.37.1/direnv.darwin-arm64"
+sha256 = "4f569f3a36732bfd8b8fea7bfcc6ad87a59745c109022164d0ca4832451d5369"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/direnv/direnv/releases/download/v2.37.1/direnv.windows-amd64"
+sha256 = "d96fc8b7cf020c2d4c1dbbc2ccec5fd1cab05b51c491f02c8527a7fa6c50a1cd"

--- a/releases/eza/0.23.4.toml
+++ b/releases/eza/0.23.4.toml
@@ -1,0 +1,17 @@
+name = "eza"
+version = "0.23.4"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/eza-community/eza/releases/download/v0.23.4/eza_x86_64-unknown-linux-gnu.tar.gz"
+sha256 = "0c38665440226cd8bef5d1d4f3bc6ff77c927fb0d68b752739105db7ab5b358d"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/eza-community/eza/releases/download/v0.23.4/eza_aarch64-unknown-linux-gnu.tar.gz"
+sha256 = "366e8430225f9955c3dc659b452150c169894833ccfef455e01765e265a3edda"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/eza-community/eza/releases/download/v0.23.4/eza.exe_x86_64-pc-windows-gnu.zip"
+sha256 = "05677fd7c2d1b69ce71df53db74c29f6331ea0b2be5aa3a0fce6976200ee06fc"

--- a/releases/hyperfine/1.20.0.toml
+++ b/releases/hyperfine/1.20.0.toml
@@ -1,0 +1,27 @@
+name = "hyperfine"
+version = "1.20.0"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/sharkdp/hyperfine/releases/download/v1.20.0/hyperfine-v1.20.0-x86_64-unknown-linux-gnu.tar.gz"
+sha256 = "63ad53934062118f5b0be11785e0bb1603d4b91667d1921f2fd8df9a8712040a"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/sharkdp/hyperfine/releases/download/v1.20.0/hyperfine-v1.20.0-aarch64-unknown-linux-gnu.tar.gz"
+sha256 = "90875cb1db7a1d797c311174d061728361e58fc70e3b62262a00635ac3b1997c"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/sharkdp/hyperfine/releases/download/v1.20.0/hyperfine-v1.20.0-x86_64-apple-darwin.tar.gz"
+sha256 = "f58d0b90993fadfa122a351428c469ce24afef3865f027f0e6e86f0830d088f1"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/sharkdp/hyperfine/releases/download/v1.20.0/hyperfine-v1.20.0-aarch64-apple-darwin.tar.gz"
+sha256 = "8ee7067016620447c9d2d6234ec9a4680f958b7ad983549b56334668f63075b5"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/sharkdp/hyperfine/releases/download/v1.20.0/hyperfine-v1.20.0-x86_64-pc-windows-msvc.zip"
+sha256 = "2508c549b049b1d4342d08edc1cb42bfac169082b6e3069431b5bab9822dbb32"

--- a/releases/sd/1.1.0.toml
+++ b/releases/sd/1.1.0.toml
@@ -1,0 +1,27 @@
+name = "sd"
+version = "1.1.0"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/chmln/sd/releases/download/v1.1.0/sd-v1.1.0-x86_64-unknown-linux-gnu.tar.gz"
+sha256 = "3613eca74cd686739bb5a6d68319aa56c747e7315274d02323a2ca2b1c5d82d2"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/chmln/sd/releases/download/v1.1.0/sd-v1.1.0-aarch64-unknown-linux-musl.tar.gz"
+sha256 = "ec8c93c0533ff21f4851d11566808d4082544baf063d9b96ea77c27e98b7cd99"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/chmln/sd/releases/download/v1.1.0/sd-v1.1.0-x86_64-apple-darwin.tar.gz"
+sha256 = "1fca1e9c91813a8aac6821063c923107ba0f66a83309e095edcd3b202f67f97e"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/chmln/sd/releases/download/v1.1.0/sd-v1.1.0-aarch64-apple-darwin.tar.gz"
+sha256 = "4bd3c09226376ca0a1d69589c91e86276fae36c5fbaaee669afce583f6682030"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/chmln/sd/releases/download/v1.1.0/sd-v1.1.0-x86_64-pc-windows-msvc.zip"
+sha256 = "59837c2e7c911099aca1cc46b663bcdc5a949fd3e9fbbaf34fc73e5d5d71007c"

--- a/releases/yq/4.53.2.toml
+++ b/releases/yq/4.53.2.toml
@@ -1,0 +1,27 @@
+name = "yq"
+version = "4.53.2"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64.tar.gz"
+sha256 = "44c3c6df6c58ef1460d98425954ca5e832926e0e8a1d75c5c8fd261691351510"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_arm64.tar.gz"
+sha256 = "c8180249ff9ff0577f4976c4481d0d0962d170d24ab390d325ef0be608df5706"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_darwin_amd64.tar.gz"
+sha256 = "48bc2dbb33f456efaf639e1e573b8e5a654701c2e92ef231e691c3971d5d4a5e"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_darwin_arm64.tar.gz"
+sha256 = "f135c0c60edd5ded11bc418d12711c259795b17501112e843e93e7a3959a3d41"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_windows_amd64.zip"
+sha256 = "63e24aac0a75b760a491002b4bbeb7078f5ec1a0c868ec60fa0f525abecd6037"

--- a/releases/zellij/0.44.1.toml
+++ b/releases/zellij/0.44.1.toml
@@ -1,0 +1,27 @@
+name = "zellij"
+version = "0.44.1"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/zellij-org/zellij/releases/download/v0.44.1/zellij-x86_64-unknown-linux-musl.tar.gz"
+sha256 = "669825021d529fca5d939888263c9d2a90762145191fa07581a15250e8af2b49"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/zellij-org/zellij/releases/download/v0.44.1/zellij-aarch64-unknown-linux-musl.tar.gz"
+sha256 = "6f028bb569d29be968c961249c5f80d5336ad4ad4b3cd79af8e32afab57b0948"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/zellij-org/zellij/releases/download/v0.44.1/zellij-x86_64-apple-darwin.tar.gz"
+sha256 = "590071e02f7733d25201ec9a97c5bd661ac7da3cbdf2ae52a11685b36654b7dc"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/zellij-org/zellij/releases/download/v0.44.1/zellij-aarch64-apple-darwin.tar.gz"
+sha256 = "544c19a9353f0ecc52877ef1e80b1c1dcbf8f258b4817077f9520099c12cc30c"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/zellij-org/zellij/releases/download/v0.44.1/zellij-x86_64-pc-windows-msvc.zip"
+sha256 = "69d7a913de40388bdb64a440b82e6ed2ac4c7232e88d0899b085c88550ec8b8f"


### PR DESCRIPTION
## Summary
- add Crosspack registry source and package manifests for seven common CLI dev tools: bottom, direnv, eza, hyperfine, sd, yq, and zellij
- add current release manifests with resolved GitHub asset URLs and SHA-256 checksums
- keep signatures out of this PR; sidecars are generated by the merge signing workflow

## Validation
- `python3 scripts/registry-validate-source.py registry/sources/eza.toml registry/sources/hyperfine.toml registry/sources/sd.toml registry/sources/bottom.toml registry/sources/yq.toml registry/sources/zellij.toml registry/sources/direnv.toml`
- `python3 scripts/registry-validate.py --allow-missing-signatures packages/eza.toml packages/hyperfine.toml packages/sd.toml packages/bottom.toml packages/yq.toml packages/zellij.toml packages/direnv.toml releases/eza/0.23.4.toml releases/hyperfine/1.20.0.toml releases/sd/1.1.0.toml releases/bottom/0.12.3.toml releases/yq/4.53.2.toml releases/zellij/0.44.1.toml releases/direnv/2.37.1.toml`
- `python3 scripts/registry-smoke-install.py releases/eza/0.23.4.toml releases/hyperfine/1.20.0.toml releases/sd/1.1.0.toml releases/bottom/0.12.3.toml releases/yq/4.53.2.toml releases/zellij/0.44.1.toml releases/direnv/2.37.1.toml`