### PR TITLE
chore(registry): add just and registry notes

### DIFF
--- a/.brv/.gitignore
+++ b/.brv/.gitignore
@@ -1,0 +1,24 @@
+# Dream state and logs
+
+# BEGIN opencode-byterover
+# Dream state and logs
+dream-log/
+dream-state.json
+dream.lock
+
+# Review backups
+review-backups/
+
+# Generated files
+config.json
+_queue_status.json
+.snapshot.json
+_manifest.json
+_index.md
+*.abstract.md
+*.overview.md
+# END opencode-byterover
+
+# Review backups
+
+# Generated files

--- a/.brv/context-tree/ci/ci-reliability-depends-on-environment-aware-tooling.md
+++ b/.brv/context-tree/ci/ci-reliability-depends-on-environment-aware-tooling.md
@@ -1,0 +1,17 @@
+---
+confidence: 0.59
+sources:
+  - ci/_index.md
+  - facts/_index.md
+synthesized_at: '2026-04-26T00:25:15.611Z'
+type: synthesis
+---
+
+# CI reliability depends on environment-aware tooling
+
+The CI fix and the stored personal preference both point to the same operational concern: the repository must behave predictably in constrained execution environments, and assumptions about local tooling should be avoided. In CI, the signing script was changed to remove its dependency on `xxd` and use `python3` instead, while the workflow redesign delays validation until signature sidecars exist, reducing race and environment-related failures.
+
+## Evidence
+
+- **ci**: `scripts/sign-changed-manifests.sh` no longer depends on `xxd`; hex encoding now uses `python3`, aligning with repository test-environment constraints.
+- **facts**: The personal facts area currently contains one lasting preference: reasoning effort = medium, explicitly reset by the user on 2026-04-26T00:05:57.857Z.

--- a/.brv/context-tree/ci/github_actions/pr_55_rework_isolation.md
+++ b/.brv/context-tree/ci/github_actions/pr_55_rework_isolation.md
@@ -1,0 +1,58 @@
+---
+title: PR 55 Rework Isolation
+summary: PR 55 was rebuilt onto current origin/main as a single clean commit, force-updated safely with --force-with-lease, and validated by the registry quality gates and test suite.
+tags: []
+related: [ci/github_actions/registry_quality_gate_and_signing_workflow_fix.md, ci/github_actions/pr_55_rework_isolation.md]
+keywords: []
+createdAt: '2026-04-26T10:36:29.731Z'
+updatedAt: '2026-04-26T10:42:25.454Z'
+---
+## Reason
+Preserve the lasting outcome of rebuilding PR 55 on current origin/main and validating the rewritten branch
+
+## Raw Concept
+**Task:**
+Rebuild PR 55 onto the current mainline after the old branch lost its merge base and validate the rewritten branch.
+
+**Changes:**
+- Observed PR 55 as open but dirty against current main
+- Observed local main as divergent and dirty
+- Used an isolated .worktrees checkout to avoid disturbing local in-progress files
+- Recreated the PR workspace under ./.worktrees/pr-55-rework
+- Replayed the PR onto current origin/main as a true rebuild
+- Skipped an empty replay for the first PR commit because it was already represented in current main
+- Reduced the rebased PR to one clean commit
+- Force-updated the PR head branch with --force-with-lease
+
+**Files:**
+- .worktrees/pr-55-rework
+- scripts/registry-validate-source.py
+- scripts/registry-validate.py
+- tests/test_registry_validate_source.py
+- tests/test_registry_generate_manifest.py
+- tests/test_upstream_release_bot.py
+
+**Flow:**
+create worktree -> detect no merge base -> replay commits -> resolve conflicts -> skip empty replay -> validate -> force-update PR branch -> wait for remaining checks
+
+**Timestamp:** 2026-04-26T10:42:18.476Z
+
+**Author:** Ian
+
+## Narrative
+### Structure
+This note captures the PR 55 rebuild process, the branch rewrite outcome, and the validation status after the rebase onto current origin/main.
+
+### Dependencies
+The rebuild depended on the current mainline state and the registry quality-gate scripts plus the test suite for verification.
+
+### Highlights
+The resulting PR is one commit ahead of current origin/main, release manifests that landed after the original PR were excluded, and all GitHub checks were passing with only review required.
+
+## Facts
+- **worktree_path**: The PR workspace was created under ./.worktrees/pr-55-rework [project]
+- **merge_base_state**: origin/main no longer shared a merge base with PR 55’s original branch [project]
+- **rebuilt_pr_commit**: The rebuilt PR was reduced to a single commit: c77144c feat(registry): generalize source model for non-github distributions [project]
+- **branch_update_method**: PR 55 was updated with --force-with-lease [project]
+- **verification_status**: Python validation and test commands passed, including the registry validators and the full test suite [project]
+- **pr_status**: GitHub PR checks all pass and the merge state is blocked only by REVIEW_REQUIRED [project]

--- a/.brv/context-tree/ci/github_actions/registry_quality_gate_and_signing_workflow_fix.md
+++ b/.brv/context-tree/ci/github_actions/registry_quality_gate_and_signing_workflow_fix.md
@@ -1,0 +1,94 @@
+---
+title: Registry Quality Gate and Signing Workflow Fix
+summary: Workflow fix work was done in ./.worktrees/fix-registry-gate-after-signing; origin/main already had the python3 portability change; validation passed with tests.test_github_workflows and full test discovery.
+tags: []
+related: [ci/github_actions/sign_manifests_on_merge.md, ci/github_actions/registry_quality_gate_and_signing_workflow_fix.md]
+keywords: []
+createdAt: '2026-04-26T00:09:44.731Z'
+updatedAt: '2026-04-26T01:33:41.225Z'
+---
+## Reason
+Record the worktree placement, workflow sequencing fix, and verification outcomes for the registry gate/signing change.
+
+## Raw Concept
+**Task:**
+Document the registry gate after signing workflow fix and its clean worktree verification.
+
+**Changes:**
+- Changed registry-quality-gate.yml from push-based validation to workflow_run after signing completes
+- Added a regression test for the GitHub workflow trigger ordering
+- Replaced xxd dependency with python3 hex encoding in sign-changed-manifests.sh
+- Created the clean PR workspace under ./.worktrees
+- Kept the branch based on origin/main
+- Confirmed origin/main already had the python3 portability fix
+- Verified the workflow test and full suite
+- Pushed the fix/registry-gate-after-signing branch and opened PR 74
+
+**Files:**
+- .github/workflows/registry-quality-gate.yml
+- .github/workflows/sign-manifests-on-merge.yml
+- tests/test_github_workflows.py
+- scripts/sign-changed-manifests.sh
+- .worktrees/fix-registry-gate-after-signing
+- tests
+
+**Flow:**
+move workspace -> base on origin/main -> apply workflow sequencing fix -> run workflow regression test -> run full test discovery -> push branch -> open PR
+
+**Timestamp:** 2026-04-25T00:00:00Z
+
+**Author:** Ian
+
+## Narrative
+### Structure
+This knowledge captures the PR workspace location, the minimal scope of the fix, and the verification steps performed in the clean worktree.
+
+### Dependencies
+The work depended on origin/main already containing the python3 portability change in the signing script.
+
+### Highlights
+Validation succeeded in a clean ./.worktrees worktree, including the workflow-specific unittest and the full suite with 33 passing tests.
+
+### Rules
+PRs still validate unsigned manifest changes, but the full signed registry scan runs after the signing workflow completes instead of racing it on the same push.
+
+### Examples
+The branch name and PR metadata are preserved for traceability: fix/registry-gate-after-signing and PR 74.
+
+## Facts
+- **worktree_location**: The clean PR workspace was moved into ./.worktrees/fix-registry-gate-after-signing. [project]
+- **signing_script_portability_change**: origin/main already included the signing-script python3 portability change. [project]
+- **remaining_work**: The PR worktree only needed the workflow sequencing fix and its regression test. [project]
+- **workflow_test**: python3 -m unittest tests.test_github_workflows passed in the clean worktree. [project]
+- **full_test_suite**: python3 -m unittest discover tests passed with 33 tests. [project]
+- **branch_name**: The branch pushed was fix/registry-gate-after-signing. [project]
+- **pull_request**: The PR was opened at pull request 74. [project]
+
+---
+
+## Key points
+- The CI race condition was fixed by changing `registry-quality-gate.yml` from a push-based trigger to a `workflow_run` trigger that runs **after** `sign-manifests-on-merge.yml` completes on `main`.
+- This ensures the registry quality gate scans **signed manifests**, avoiding evaluation of the merge commit before signature sidecars exist.
+- A regression test was added in `tests/test_github_workflows.py` to prevent the trigger-ordering bug from returning.
+- `scripts/sign-changed-manifests.sh` was made more portable by replacing the `xxd` dependency with `python3`-based hex encoding.
+- Validation behavior remains split: PRs still validate unsigned manifest changes, while the full signed registry scan happens only after signing finishes.
+- Reported test results indicate the focused workflow tests, signing-script tests, and the full suite all passed, with the suite totaling 22 tests.
+
+## Structure / sections summary
+- **Reason**: States the purpose — documenting the CI race fix and related test/portability updates.
+- **Raw Concept**: Summarizes the concrete task, file changes, workflow flow, and timestamp.
+- **Narrative**: Explains the architectural intent, dependency ordering, testing highlights, and behavioral rules.
+- **Facts**: Lists specific project facts, including trigger changes, test status, portability fix, and unrelated worktree changes left untouched.
+
+## Notable entities, patterns, or decisions
+- **Workflows involved**:
+  - `.github/workflows/registry-quality-gate.yml`
+  - `.github/workflows/sign-manifests-on-merge.yml`
+- **Test file**:
+  - `tests/test_github_workflows.py`
+- **Script updated for portability**:
+  - `scripts/sign-changed-manifests.sh`
+- **Design decision**: Use `workflow_run` to serialize signing before quality gating, eliminating same-push race conditions.
+- **Implementation pattern**: Keep lightweight PR validation separate from the heavier signed registry scan.
+- **Environment constraint**: `xxd` was unavailable in the test environment, motivating the switch to `python3`.
+- **Workflow order**: `merge on main -> sign manifests workflow -> registry quality gate signed scan -> tests verify ordering and portability`

--- a/.brv/context-tree/facts/personal/reasoning_effort_preference.md
+++ b/.brv/context-tree/facts/personal/reasoning_effort_preference.md
@@ -1,0 +1,50 @@
+---
+title: Reasoning Effort Preference
+summary: Reasoning effort is set to medium, and work should use an isolated worktree when local main is dirty and divergent.
+tags: []
+related: []
+keywords: []
+createdAt: '2026-04-26T01:24:46.747Z'
+updatedAt: '2026-04-26T10:36:30.025Z'
+---
+## Reason
+Capture stated reasoning effort preference and working mode note
+
+## Raw Concept
+**Task:**
+Document preference and repository handling notes from the conversation
+
+**Changes:**
+- Set reasoning effort to medium
+- Reasoning effort was set to medium
+- Use a clean worktree from origin/main for the CI fix
+- Commit only the CI fix files and open the PR against main
+- Set reasoning effort preference to high
+- Recorded reasoning effort preference as medium
+- Recorded PR 55 and local main branch state
+- Recorded use of an isolated worktree for safe rework
+
+**Flow:**
+inspect PR and branch state -> use isolated worktree -> avoid disturbing local in-progress files
+
+**Timestamp:** 2026-04-26T10:36:25.062Z
+
+## Narrative
+### Structure
+The note combines a user preference with repository state constraints relevant to ongoing work.
+
+### Dependencies
+Safe rework depends on avoiding the dirty, divergent local main checkout by using .worktrees.
+
+### Highlights
+The assistant chose the smallest safe rework path and isolated the checkout to protect local work.
+
+## Facts
+- **reasoning_effort**: Reasoning effort reset to medium. [preference]
+- **pr_55_state**: PR 55 is open but dirty against current main. [project]
+- **local_main_state**: Local main is divergent and dirty. [project]
+- **worktree_strategy**: An isolated .worktrees checkout is used so the rework does not disturb local in-progress files. [project]
+
+---
+
+Reasoning effort preference history: the user first set reasoning effort to high at 2026-04-26T00:05:57.764Z, then later reset it to medium at 2026-04-26T00:05:57.857Z. The current effective preference is medium, while the earlier high setting is preserved as historical context. Keep both events with explicit chronology so future readers can see the transition from high to medium.

--- a/.brv/context-tree/facts/preference/reasoning_effort_preference.md
+++ b/.brv/context-tree/facts/preference/reasoning_effort_preference.md
@@ -1,0 +1,42 @@
+---
+title: Reasoning Effort Preference
+summary: User preference updated to medium reasoning effort.
+tags: []
+related: []
+keywords: []
+createdAt: '2026-04-26T00:06:01.695Z'
+updatedAt: '2026-04-26T10:29:33.812Z'
+---
+## Reason
+Record explicit user preference update for reasoning effort.
+
+## Raw Concept
+**Task:**
+Capture the user's reasoning effort preference update
+
+**Changes:**
+- Set reasoning effort to high
+- Set reasoning effort to medium
+- Chose a clean worktree from origin/main
+- Scoped the PR to only the CI fix files
+- Reasoning effort reset to medium
+
+**Flow:**
+user preference update -> record durable preference
+
+**Timestamp:** 2026-04-26
+
+**Author:** user
+
+## Narrative
+### Structure
+A single preference entry recording the current reasoning-effort setting.
+
+### Dependencies
+The decision depended on the local main branch being ahead of and behind origin/main, which would have made a PR noisy.
+
+### Highlights
+The user explicitly reset reasoning effort to medium.
+
+## Facts
+- **reasoning_effort**: Reasoning effort reset to medium [preference]

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 logs/*.log
 artifacts/
 **/__pycache__/
+.opencode/package-lock.json

--- a/docs/day-one-seed-package-set.md
+++ b/docs/day-one-seed-package-set.md
@@ -1,0 +1,483 @@
+# Crosspack Registry day-one seed package set recommendation
+
+Date: 2026-03-31
+Issue: SPI-11
+Project: Crosspack Registry
+
+## Executive recommendation
+
+Recommended day-one seed set of 5:
+1. crosspack
+2. ripgrep
+3. fd
+4. uv
+5. gh
+
+Why this 5:
+- strongest demo value for Crosspack’s core promise: trustworthy cross-platform CLI installs
+- high recognition among developers on Windows, macOS, and Linux
+- mostly simple GitHub-release sourcing with deterministic asset naming
+- low metadata risk relative to GUI apps and vendor-specific installers
+- enough breadth to demo search, info, install, upgrade, checksums, signatures, and shell integration without turning the registry into a support burden
+
+Confidence: medium-high
+
+## Selection criteria used
+
+Weighted highest:
+- cross-platform coverage for Linux + macOS + Windows
+- upstream release stability and machine-friendly asset naming
+- install trust/demo value for developer audiences
+- low ongoing metadata maintenance burden
+- low first-wave platform caveat risk
+
+Weighted lower for day one:
+- large GUI apps with heavier platform-specific packaging
+- packages with uneven target coverage
+- packages that are valuable later but do not sharpen the initial Crosspack story
+
+## Current candidate universe (10-15 packages to support first)
+
+These are the strongest current candidates from the existing registry/source-config set.
+
+### Tier 1: recommended day-one seed set
+
+#### 1) crosspack
+Why it matters
+- essential trust demo: users can inspect how Crosspack packages itself
+- proves registry automation, release ingestion, and self-update path
+- gives the project an obvious canonical package to validate end to end
+
+Upstream source
+- GitHub releases: spiritledsoftware/crosspack
+- Source config: `registry/sources/crosspack.toml`
+
+Version/update strategy
+- automated from GitHub releases with `tag_prefix = "v"`
+- should stay tightly coupled to Crosspack release workflow and registry-sync automation
+
+Metadata requirements
+- package template with 7 targets
+- release docs with per-target HTTPS URL + SHA-256
+- binaries: `crosspack`, plus Windows alias `cpk`
+- tar.gz + zip only, no GUI handling
+
+Platform caveats
+- current source config covers strong breadth, including linux glibc and musl variants
+- registry currently trails repo release line in `releases/crosspack/` (latest file present is 0.9.0 while main repo shows v0.10.x tags), so freshness monitoring matters
+
+Decision note
+- must be in day one because it makes the registry easier to trust
+
+#### 2) ripgrep
+Why it matters
+- widely known CLI benchmark package
+- perfect demo package for search/install/info flows
+- includes shell completion metadata, which helps show Crosspack’s completion handling
+
+Upstream source
+- GitHub releases: BurntSushi/ripgrep
+- Source config: `registry/sources/ripgrep.toml`
+
+Version/update strategy
+- automated from GitHub releases
+- no explicit tag prefix needed; tags normalize cleanly
+
+Metadata requirements
+- 6 targets across Linux/macOS/Windows incl. arm64 variants
+- tar.gz + zip
+- `strip_components` differs by platform
+- binaries: `rg`
+- completions: bash, zsh, fish, powershell
+
+Platform caveats
+- Linux x86_64 target uses musl asset while target label is `x86_64-unknown-linux-gnu`; acceptable if install/runtime testing stays green, but it is worth documenting explicitly
+
+Decision note
+- one of the best possible “hello world” packages for developer adoption
+
+#### 3) fd
+Why it matters
+- pairs naturally with ripgrep in demos
+- high developer familiarity
+- includes completions, which enriches install proof
+- simple binary release pattern
+
+Upstream source
+- GitHub releases: sharkdp/fd
+- Source config: `registry/sources/fd.toml`
+
+Version/update strategy
+- automated from GitHub releases with `tag_prefix = "v"`
+
+Metadata requirements
+- 6 targets across Linux/macOS/Windows incl. arm64 Windows
+- tar.gz + zip
+- completions for bash, zsh, fish, powershell
+- binaries: `fd`
+
+Platform caveats
+- low caveat package overall
+- keep an eye on archive internal paths because completion paths are archive-relative
+
+Decision note
+- very strong day-one package because it is simple, trusted, and demo-friendly
+
+#### 4) uv
+Why it matters
+- high-growth developer tool with strong mindshare
+- demonstrates that Crosspack can install modern dev workflow tooling, not just classic Unix utilities
+- shipping both `uv` and `uvx` is a nice proof of multi-binary package support
+
+Upstream source
+- GitHub releases: astral-sh/uv
+- Source config: `registry/sources/uv.toml`
+
+Version/update strategy
+- automated from GitHub releases
+- no tag prefix required in source config
+
+Metadata requirements
+- 5 targets across Linux/macOS/Windows
+- tar.gz + zip
+- binaries: `uv`, `uvx`
+- `strip_components = 1`
+
+Platform caveats
+- no Linux musl target in current config; acceptable for day one but reduces “runs everywhere” breadth versus crosspack/ripgrep/fd
+
+Decision note
+- best choice for proving relevance to active Python/AI/dev-tool users
+
+#### 5) gh
+Why it matters
+- very recognizable developer utility
+- helps position Crosspack as a serious CLI package manager, not a toy demo
+- clean install story across major OSes
+
+Upstream source
+- GitHub releases: cli/cli
+- Source config: `registry/sources/gh.toml`
+
+Version/update strategy
+- automated from GitHub releases with `tag_prefix = "v"`
+
+Metadata requirements
+- 5 targets across Linux/macOS/Windows
+- tar.gz + zip
+- binary: `gh`
+- archive paths use `bin/gh` / `bin/gh.exe`
+
+Platform caveats
+- no Windows arm64 target in current config
+- otherwise low-risk package
+
+Decision note
+- strong trust package because users already know what “good” distribution should look like here
+
+### Tier 2: first expansion wave after day one
+
+#### 6) jq
+Why it matters
+- extremely common utility and easy search/info/install demo
+- metadata is simple because artifacts are direct binaries
+
+Upstream source
+- GitHub releases: jqlang/jq
+- Source config: `registry/sources/jq.toml`
+
+Version/update strategy
+- automated from GitHub releases
+
+Metadata requirements
+- 5 targets
+- binary assets, no archive extraction
+- binary: `jq`
+
+Platform caveats
+- fewer bells and whistles than ripgrep/fd, so it is slightly less useful as a flagship demo even though it is easy to maintain
+
+Why not day one
+- very good package, but less distinctive as a flagship than ripgrep/fd/uv/gh
+
+#### 7) fzf
+Why it matters
+- strong developer recognition
+- good cross-platform CLI example
+
+Upstream source
+- GitHub releases: junegunn/fzf
+- Source config: `registry/sources/fzf.toml`
+
+Version/update strategy
+- automated from GitHub releases with `tag_prefix = "v"`
+
+Metadata requirements
+- 6 targets incl. arm64 Windows
+- tar.gz + zip
+- binary: `fzf`
+
+Platform caveats
+- no completion metadata in current source config, so the demo story is slightly thinner than fd/ripgrep
+
+Why not day one
+- excellent second-wave package, but fd and ripgrep tell a better immediate story
+
+#### 8) lazygit
+Why it matters
+- very popular dev CLI
+- good proof that Crosspack can handle workflow tools beyond text utilities
+
+Upstream source
+- GitHub releases: jesseduffield/lazygit
+- Source config: `registry/sources/lazygit.toml`
+
+Version/update strategy
+- automated from GitHub releases with `tag_prefix = "v"`
+
+Metadata requirements
+- 5 targets
+- tar.gz + zip
+- binary: `lazygit`
+
+Platform caveats
+- no major known caveats from current metadata
+
+Why not day one
+- great expansion package, but not as universally “obvious” as gh or ripgrep
+
+#### 9) bat
+Why it matters
+- popular cross-platform CLI
+- easy maintenance pattern
+
+Upstream source
+- GitHub releases: sharkdp/bat
+- Source config: `registry/sources/bat.toml`
+
+Version/update strategy
+- automated from GitHub releases with `tag_prefix = "v"`
+
+Metadata requirements
+- 5 targets
+- tar.gz + zip
+- binary: `bat`
+
+Platform caveats
+- current source config does not capture shell completions, which lowers demo richness versus fd/ripgrep
+
+Why not day one
+- good package, but slightly redundant with fd/ripgrep in the first impression set
+
+#### 10) delta
+Why it matters
+- respected developer CLI and good Git-adjacent tool
+
+Upstream source
+- GitHub releases: dandavison/delta
+- Source config: `registry/sources/delta.toml`
+
+Version/update strategy
+- automated from GitHub releases
+
+Metadata requirements
+- 5 targets
+- tar.gz + zip
+- binary: `delta`
+
+Platform caveats
+- straightforward package; lower brand recognition than gh/ripgrep/fd
+
+Why not day one
+- useful but not essential to the initial demo set
+
+### Tier 3: valuable later, but higher support or narrative cost
+
+#### 11) starship
+Why it matters
+- high developer awareness
+- shell-oriented tool that can broaden package mix
+
+Upstream source
+- GitHub releases: starship/starship
+- Source config: `registry/sources/starship.toml`
+
+Version/update strategy
+- automated from GitHub releases with `tag_prefix = "v"`
+
+Metadata requirements
+- 5 targets
+- tar.gz + zip
+- binary: `starship`
+
+Platform caveats
+- Linux coverage is split between gnu and musl rather than a fuller symmetric target matrix
+
+Why later
+- useful, but day-one story is stronger with packages users execute directly after install for visible payoff
+
+#### 12) bruno
+Why it matters
+- modern API client with increasing mindshare
+- strong proof that Crosspack can handle GUI app metadata too
+
+Upstream source
+- GitHub releases: usebruno/bruno
+- Source config: `registry/sources/bruno.toml`
+
+Version/update strategy
+- automated from GitHub releases with `tag_prefix = "v"`
+
+Metadata requirements
+- 6 targets including arm64 Windows
+- AppImage, dmg, and exe assets
+- GUI metadata plus binary paths
+
+Platform caveats
+- GUI packaging and OS-specific install behavior raise day-one support complexity
+
+Why later
+- strong package, but GUI-heavy packages are better after core CLI trust is established
+
+#### 13) dbeaver
+Why it matters
+- recognizable database GUI
+- useful for proving broader package scope
+
+Upstream source
+- GitHub releases: dbeaver/dbeaver
+- Source config: `registry/sources/dbeaver.toml`
+
+Version/update strategy
+- automated from GitHub releases
+
+Metadata requirements
+- 6 targets
+- mixed asset kinds across tar.gz/zip/direct binary installers
+- GUI metadata
+
+Platform caveats
+- heavier platform-specific variation than the day-one CLI set
+
+Why later
+- valuable expansion package, but higher maintenance surface
+
+#### 14) beekeeper-studio
+Why it matters
+- another strong database GUI option
+- good for modern developer GUI coverage
+
+Upstream source
+- GitHub releases: beekeeper-studio/beekeeper-studio
+- Source config: `registry/sources/beekeeper-studio.toml`
+
+Version/update strategy
+- automated from GitHub releases with `tag_prefix = "v"`
+
+Metadata requirements
+- 5 targets
+- AppImage/dmg/portable exe style assets
+- GUI metadata
+
+Platform caveats
+- GUI complexity similar to Bruno/DBeaver
+
+Why later
+- compelling package, but not needed for day-one trust demo
+
+#### 15) neovide
+Why it matters
+- attractive GUI showcase for editor users
+- can demonstrate app-bundle handling
+
+Upstream source
+- GitHub releases: neovide/neovide
+- Source config: `registry/sources/neovide.toml`
+
+Version/update strategy
+- automated from GitHub releases
+
+Metadata requirements
+- 4 targets only
+- tar.gz + dmg + zip/exe patterns
+- GUI metadata
+
+Platform caveats
+- weaker target coverage than the top CLI choices
+
+Why later
+- more niche and less symmetric cross-platform coverage
+
+## Packages I would not prioritize for day one
+
+- insomnia
+  - useful, but GUI-first and only 4 configured targets
+- redisinsight
+  - valuable later for database workflows, but GUI-heavy and not central to the first trust demo
+
+## Metadata sourcing pattern to standardize
+
+For the recommended day-one set, the common pattern is strong and repeatable:
+- upstream discovery source: GitHub Releases API
+- package template source-of-truth: `registry/sources/<package>.toml`
+- generated outputs:
+  - `packages/<package>.toml`
+  - `releases/<package>/<version>.toml`
+- signing flow:
+  - merged docs are signed on main by `.github/workflows/sign-manifests-on-merge.yml`
+- validation flow:
+  - `scripts/registry-preflight.sh`
+  - schema + smoke-install checks
+
+This is exactly the kind of operational consistency that makes the registry easier to trust.
+
+## Day-one operating recommendation
+
+Launch with:
+- crosspack
+- ripgrep
+- fd
+- uv
+- gh
+
+Then add in this order:
+- jq
+- fzf
+- lazygit
+- bat
+- delta
+- starship
+- bruno
+- dbeaver
+- beekeeper-studio
+- neovide
+
+## Key recommendation for adoption
+
+If the goal is to make Crosspack easier to demo and easier to trust, optimize the first impression around “boringly reliable developer CLI installs,” not around breadth.
+
+That means:
+- prefer known CLI tools before GUI apps
+- prefer packages with clear GitHub release assets and strong platform symmetry
+- include at least two packages with richer metadata behavior (ripgrep/fd completions, uv multi-binary)
+- keep Crosspack itself in the set to prove the registry can publish and trust its own flagship package
+
+## Confidence and uncertainty
+
+Confidence: medium-high
+
+What is factual here
+- current package/source-config inventory
+- target coverage, archive kinds, binary/completion/gui metadata observed in `registry/sources/*.toml`
+- current release presence in `releases/*`
+- Crosspack registry structure and automation documented in repo docs and scripts
+
+What is inferred
+- relative adoption/demo value by package
+- likely maintenance burden by package class
+- recommended ordering for day-one vs expansion wave
+
+What I would verify next if we wanted to tighten confidence further
+- actual release cadence and asset naming stability over the last 6-12 months for the top 10 packages
+- smoke-install success rate by target for the recommended day-one 5
+- whether Linux target labels and actual upstream binaries should be normalized more explicitly for a few packages (for example ripgrep musl/glibc naming)

--- a/packages/just.toml
+++ b/packages/just.toml
@@ -1,0 +1,68 @@
+name = "just"
+license = "CC0-1.0"
+homepage = "https://github.com/casey/just"
+
+[source]
+provider = "github"
+repo = "casey/just"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-musl"
+asset = "just-{version}-x86_64-unknown-linux-musl.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "just"
+path = "just"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-musl"
+asset = "just-{version}-aarch64-unknown-linux-musl.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "just"
+path = "just"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "just-{version}-x86_64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "just"
+path = "just"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "just-{version}-aarch64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "just"
+path = "just"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "just-{version}-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "just"
+path = "just.exe"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "just-{version}-aarch64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "just"
+path = "just.exe"

--- a/registry/sources/just.toml
+++ b/registry/sources/just.toml
@@ -1,0 +1,68 @@
+name = "just"
+license = "CC0-1.0"
+homepage = "https://github.com/casey/just"
+
+[source]
+provider = "github"
+repo = "casey/just"
+include_prereleases = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-musl"
+asset = "just-{version}-x86_64-unknown-linux-musl.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "just"
+path = "just"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-musl"
+asset = "just-{version}-aarch64-unknown-linux-musl.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "just"
+path = "just"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "just-{version}-x86_64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "just"
+path = "just"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "just-{version}-aarch64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "just"
+path = "just"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "just-{version}-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "just"
+path = "just.exe"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "just-{version}-aarch64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "just"
+path = "just.exe"

--- a/releases/just/1.48.1.toml
+++ b/releases/just/1.48.1.toml
@@ -1,0 +1,32 @@
+name = "just"
+version = "1.48.1"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-musl"
+url = "https://github.com/casey/just/releases/download/1.48.1/just-1.48.1-x86_64-unknown-linux-musl.tar.gz"
+sha256 = "9293e553ce401d1b524bf4e104918f72f268e3f9c6827e0055fe98d84a1b2522"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-musl"
+url = "https://github.com/casey/just/releases/download/1.48.1/just-1.48.1-aarch64-unknown-linux-musl.tar.gz"
+sha256 = "3308721b991cf88cf2b9bbb3b31ac40550ec61a0c9b6fc011564e25e87964030"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/casey/just/releases/download/1.48.1/just-1.48.1-x86_64-apple-darwin.tar.gz"
+sha256 = "4c3e9c880b8fc93d7fc24abfde3c36b0cc59f6e9f8b31f7175095700f64125a7"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/casey/just/releases/download/1.48.1/just-1.48.1-aarch64-apple-darwin.tar.gz"
+sha256 = "03a73339ff55bcf7411a3c940cdcb0a726d98134b87203c83a9008575434e2a8"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/casey/just/releases/download/1.48.1/just-1.48.1-x86_64-pc-windows-msvc.zip"
+sha256 = "368cd9ca827cba04d9e6fc00f7ad840773c4605b6f64b9f87bdb00325d351029"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+url = "https://github.com/casey/just/releases/download/1.48.1/just-1.48.1-aarch64-pc-windows-msvc.zip"
+sha256 = "ed9cd54e46d65770bf0b79c051761b29f0b89a88e56e8cae4454ec7246c82160"

--- a/scripts/sign-changed-manifests.sh
+++ b/scripts/sign-changed-manifests.sh
@@ -47,8 +47,12 @@ chmod 600 "$key_file"
 for manifest in "${changed_manifests[@]}"; do
   sig_bin="$(mktemp)"
   openssl pkeyutl -sign -rawin -inkey "$key_file" -in "$manifest" -out "$sig_bin"
-  python3 -c 'import pathlib, sys; sys.stdout.write(pathlib.Path(sys.argv[1]).read_bytes().hex())' "$sig_bin" > "${manifest}.sig"
-  printf '\n' >> "${manifest}.sig"
+  python3 - "$sig_bin" "${manifest}.sig" <<'PY'
+from pathlib import Path
+import sys
+
+Path(sys.argv[2]).write_text(Path(sys.argv[1]).read_bytes().hex() + "\n", encoding="utf-8")
+PY
   rm -f "$sig_bin"
   echo "signed ${manifest}"
 done


### PR DESCRIPTION
## Summary
- add `just` package/source/release manifests for `1.48.1`
- add day-one seed package recommendation notes and checked-in `.brv` context files
- ignore `.opencode/package-lock.json`, remove empty logs placeholder, and simplify signature hex writing

## Validation
- `python3 scripts/registry-validate-source.py registry/sources/just.toml`
- `python3 scripts/registry-validate.py --allow-missing-signatures packages/just.toml releases/just/1.48.1.toml`
- `python3 scripts/registry-smoke-install.py releases/just/1.48.1.toml`
- `python3 -m unittest tests/test_github_workflows.py`
- `REGISTRY_REQUIRE_SIGNATURES=0 REGISTRY_PREFLIGHT_SKIP_SMOKE=1 ./scripts/registry-preflight.sh`