### PR TITLE
feat(registry): add typed integration package metadata

### DIFF
--- a/packages/cosign.toml
+++ b/packages/cosign.toml
@@ -1,0 +1,68 @@
+name = "cosign"
+license = "Apache-2.0"
+homepage = "https://github.com/sigstore/cosign"
+
+[source.release]
+kind = "github_releases"
+repo = "sigstore/cosign"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "asset_digest"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "cosign-linux-amd64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "cosign"
+path = "cosign"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "cosign-linux-arm64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "cosign"
+path = "cosign"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "cosign-darwin-amd64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "cosign"
+path = "cosign"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "cosign-darwin-arm64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "cosign"
+path = "cosign"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "cosign-windows-amd64.exe"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "cosign"
+path = "cosign.exe"

--- a/packages/docker-compose.toml
+++ b/packages/docker-compose.toml
@@ -1,0 +1,73 @@
+name = "docker-compose"
+license = "Apache-2.0"
+homepage = "https://github.com/docker/compose"
+
+[source.release]
+kind = "github_releases"
+repo = "docker/compose"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "asset_digest"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[integrations]]
+kind = "docker_cli_plugin"
+name = "compose"
+source = "artifact.bin"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "docker-compose-linux-x86_64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "docker-compose"
+path = "artifact.bin"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "docker-compose-linux-aarch64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "docker-compose"
+path = "artifact.bin"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "docker-compose-darwin-x86_64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "docker-compose"
+path = "artifact.bin"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "docker-compose-darwin-aarch64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "docker-compose"
+path = "artifact.bin"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "docker-compose-windows-x86_64.exe"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "docker-compose"
+path = "artifact.bin"

--- a/packages/flux.toml
+++ b/packages/flux.toml
@@ -1,0 +1,78 @@
+name = "flux"
+license = "Apache-2.0"
+homepage = "https://github.com/fluxcd/flux2"
+
+[source.release]
+kind = "github_releases"
+repo = "fluxcd/flux2"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "asset_digest"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "flux_{version}_linux_amd64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "flux"
+path = "flux"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "flux_{version}_linux_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "flux"
+path = "flux"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "flux_{version}_darwin_amd64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "flux"
+path = "flux"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "flux_{version}_darwin_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "flux"
+path = "flux"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "flux_{version}_windows_amd64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "flux"
+path = "flux.exe"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "flux_{version}_windows_arm64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "flux"
+path = "flux.exe"

--- a/packages/gum.toml
+++ b/packages/gum.toml
@@ -1,0 +1,68 @@
+name = "gum"
+license = "MIT"
+homepage = "https://github.com/charmbracelet/gum"
+
+[source.release]
+kind = "github_releases"
+repo = "charmbracelet/gum"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "asset_digest"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "gum_{version}_Linux_x86_64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "gum"
+path = "gum"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "gum_{version}_Linux_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "gum"
+path = "gum"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "gum_{version}_Darwin_x86_64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "gum"
+path = "gum"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "gum_{version}_Darwin_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "gum"
+path = "gum"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "gum_{version}_Windows_x86_64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "gum"
+path = "gum.exe"

--- a/packages/helix.toml
+++ b/packages/helix.toml
@@ -1,0 +1,67 @@
+name = "helix"
+license = "MPL-2.0"
+homepage = "https://github.com/helix-editor/helix"
+
+[source.release]
+kind = "github_releases"
+repo = "helix-editor/helix"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "asset_digest"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "helix-{version}-x86_64-linux.tar.xz"
+archive = "tar.xz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "hx"
+path = "hx"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "helix-{version}-aarch64-linux.tar.xz"
+archive = "tar.xz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "hx"
+path = "hx"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "helix-{version}-x86_64-macos.tar.xz"
+archive = "tar.xz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "hx"
+path = "hx"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "helix-{version}-aarch64-macos.tar.xz"
+archive = "tar.xz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "hx"
+path = "hx"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "helix-{version}-x86_64-windows.zip"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "hx"
+path = "hx.exe"

--- a/packages/helm.toml
+++ b/packages/helm.toml
@@ -1,0 +1,80 @@
+name = "helm"
+license = "Apache-2.0"
+homepage = "https://github.com/helm/helm"
+
+[source.release]
+kind = "github_releases"
+repo = "helm/helm"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "url_sha256"
+url_template = "{url}.sha256sum"
+
+[source.asset]
+kind = "templated"
+base_url = "https://get.helm.sh"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "helm-v{version}-linux-amd64.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "helm"
+path = "helm"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "helm-v{version}-linux-arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "helm"
+path = "helm"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "helm-v{version}-darwin-amd64.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "helm"
+path = "helm"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "helm-v{version}-darwin-arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "helm"
+path = "helm"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "helm-v{version}-windows-amd64.zip"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "helm"
+path = "helm.exe"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "helm-v{version}-windows-arm64.zip"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "helm"
+path = "helm.exe"

--- a/packages/k9s.toml
+++ b/packages/k9s.toml
@@ -1,0 +1,78 @@
+name = "k9s"
+license = "Apache-2.0"
+homepage = "https://github.com/derailed/k9s"
+
+[source.release]
+kind = "github_releases"
+repo = "derailed/k9s"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "asset_digest"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "k9s_Linux_amd64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "k9s"
+path = "k9s"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "k9s_Linux_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "k9s"
+path = "k9s"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "k9s_Darwin_amd64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "k9s"
+path = "k9s"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "k9s_Darwin_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "k9s"
+path = "k9s"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "k9s_Windows_amd64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "k9s"
+path = "k9s.exe"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "k9s_Windows_arm64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "k9s"
+path = "k9s.exe"

--- a/packages/kind.toml
+++ b/packages/kind.toml
@@ -1,0 +1,68 @@
+name = "kind"
+license = "Apache-2.0"
+homepage = "https://github.com/kubernetes-sigs/kind"
+
+[source.release]
+kind = "github_releases"
+repo = "kubernetes-sigs/kind"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "asset_digest"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "kind-linux-amd64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kind"
+path = "kind"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "kind-linux-arm64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kind"
+path = "kind"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "kind-darwin-amd64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kind"
+path = "kind"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "kind-darwin-arm64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kind"
+path = "kind"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "kind-windows-amd64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kind"
+path = "kind.exe"

--- a/packages/kubecolor.toml
+++ b/packages/kubecolor.toml
@@ -1,0 +1,78 @@
+name = "kubecolor"
+license = "MIT"
+homepage = "https://github.com/kubecolor/kubecolor"
+
+[source.release]
+kind = "github_releases"
+repo = "kubecolor/kubecolor"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "asset_digest"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "kubecolor_{version}_linux_amd64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kubecolor"
+path = "kubecolor"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "kubecolor_{version}_linux_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kubecolor"
+path = "kubecolor"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "kubecolor_{version}_darwin_amd64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kubecolor"
+path = "kubecolor"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "kubecolor_{version}_darwin_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kubecolor"
+path = "kubecolor"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "kubecolor_{version}_windows_amd64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kubecolor"
+path = "kubecolor.exe"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "kubecolor_{version}_windows_arm64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kubecolor"
+path = "kubecolor.exe"

--- a/packages/kubectx.toml
+++ b/packages/kubectx.toml
@@ -1,0 +1,74 @@
+name = "kubectx"
+license = "Apache-2.0"
+homepage = "https://github.com/ahmetb/kubectx"
+
+[source.release]
+kind = "github_releases"
+repo = "ahmetb/kubectx"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "asset_digest"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[integrations]]
+kind = "path_plugin"
+host = "kubectl"
+name = "ctx"
+source = "kubectx"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "kubectx_v{version}_linux_x86_64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kubectl-ctx"
+path = "kubectx"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "kubectx_v{version}_linux_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kubectl-ctx"
+path = "kubectx"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "kubectx_v{version}_darwin_x86_64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kubectl-ctx"
+path = "kubectx"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "kubectx_v{version}_darwin_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kubectl-ctx"
+path = "kubectx"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "kubectx_v{version}_windows_x86_64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kubectl-ctx"
+path = "kubectx.exe"

--- a/packages/kustomize.toml
+++ b/packages/kustomize.toml
@@ -1,0 +1,78 @@
+name = "kustomize"
+license = "Apache-2.0"
+homepage = "https://github.com/kubernetes-sigs/kustomize"
+
+[source.release]
+kind = "github_releases"
+repo = "kubernetes-sigs/kustomize"
+tag_prefix = "kustomize/v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "asset_digest"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "kustomize_v{version}_linux_amd64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kustomize"
+path = "kustomize"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "kustomize_v{version}_linux_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kustomize"
+path = "kustomize"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "kustomize_v{version}_darwin_amd64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kustomize"
+path = "kustomize"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "kustomize_v{version}_darwin_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kustomize"
+path = "kustomize"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "kustomize_v{version}_windows_amd64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kustomize"
+path = "kustomize.exe"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "kustomize_v{version}_windows_arm64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kustomize"
+path = "kustomize.exe"

--- a/packages/lazydocker.toml
+++ b/packages/lazydocker.toml
@@ -1,0 +1,78 @@
+name = "lazydocker"
+license = "MIT"
+homepage = "https://github.com/jesseduffield/lazydocker"
+
+[source.release]
+kind = "github_releases"
+repo = "jesseduffield/lazydocker"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "asset_digest"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "lazydocker_{version}_Linux_x86_64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "lazydocker"
+path = "lazydocker"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "lazydocker_{version}_Linux_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "lazydocker"
+path = "lazydocker"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "lazydocker_{version}_Darwin_x86_64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "lazydocker"
+path = "lazydocker"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "lazydocker_{version}_Darwin_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "lazydocker"
+path = "lazydocker"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "lazydocker_{version}_Windows_x86_64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "lazydocker"
+path = "lazydocker.exe"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "lazydocker_{version}_Windows_arm64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "lazydocker"
+path = "lazydocker.exe"

--- a/packages/minikube.toml
+++ b/packages/minikube.toml
@@ -1,0 +1,68 @@
+name = "minikube"
+license = "Apache-2.0"
+homepage = "https://github.com/kubernetes/minikube"
+
+[source.release]
+kind = "github_releases"
+repo = "kubernetes/minikube"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "asset_digest"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "minikube-linux-amd64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "minikube"
+path = "minikube"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "minikube-linux-arm64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "minikube"
+path = "minikube"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "minikube-darwin-amd64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "minikube"
+path = "minikube"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "minikube-darwin-arm64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "minikube"
+path = "minikube"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "minikube-windows-amd64.exe"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "minikube"
+path = "minikube.exe"

--- a/packages/oras.toml
+++ b/packages/oras.toml
@@ -1,0 +1,68 @@
+name = "oras"
+license = "Apache-2.0"
+homepage = "https://github.com/oras-project/oras"
+
+[source.release]
+kind = "github_releases"
+repo = "oras-project/oras"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "asset_digest"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "oras_{version}_linux_amd64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "oras"
+path = "oras"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "oras_{version}_linux_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "oras"
+path = "oras"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "oras_{version}_darwin_amd64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "oras"
+path = "oras"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "oras_{version}_darwin_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "oras"
+path = "oras"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "oras_{version}_windows_amd64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "oras"
+path = "oras.exe"

--- a/packages/sops.toml
+++ b/packages/sops.toml
@@ -1,0 +1,78 @@
+name = "sops"
+license = "MPL-2.0"
+homepage = "https://github.com/getsops/sops"
+
+[source.release]
+kind = "github_releases"
+repo = "getsops/sops"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "asset_digest"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "sops-v{version}.linux.amd64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "sops"
+path = "vendor/bin/sops"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "sops-v{version}.linux.arm64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "sops"
+path = "vendor/bin/sops"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "sops-v{version}.darwin.amd64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "sops"
+path = "vendor/bin/sops"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "sops-v{version}.darwin.arm64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "sops"
+path = "vendor/bin/sops"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "sops-v{version}.amd64.exe"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "sops"
+path = "vendor/bin/sops.exe"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "sops-v{version}.arm64.exe"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "sops"
+path = "vendor/bin/sops.exe"

--- a/packages/syncthing.toml
+++ b/packages/syncthing.toml
@@ -1,0 +1,44 @@
+name = "syncthing"
+license = "MPL-2.0"
+homepage = "https://github.com/syncthing/syncthing"
+
+[source.release]
+kind = "github_releases"
+repo = "syncthing/syncthing"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "asset_digest"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[integrations]]
+kind = "service"
+name = "syncthing"
+source = "etc/linux-systemd/system/syncthing.service"
+enable = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "syncthing-linux-amd64-v{version}.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "syncthing"
+path = "syncthing"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "syncthing-linux-arm64-v{version}.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "syncthing"
+path = "syncthing"

--- a/packages/trivy.toml
+++ b/packages/trivy.toml
@@ -1,0 +1,68 @@
+name = "trivy"
+license = "Apache-2.0"
+homepage = "https://github.com/aquasecurity/trivy"
+
+[source.release]
+kind = "github_releases"
+repo = "aquasecurity/trivy"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "asset_digest"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "trivy_{version}_Linux-64bit.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "trivy"
+path = "trivy"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "trivy_{version}_Linux-ARM64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "trivy"
+path = "trivy"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "trivy_{version}_macOS-64bit.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "trivy"
+path = "trivy"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "trivy_{version}_macOS-ARM64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "trivy"
+path = "trivy"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "trivy_{version}_windows-64bit.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "trivy"
+path = "trivy.exe"

--- a/releases/cosign/3.0.6.toml
+++ b/releases/cosign/3.0.6.toml
@@ -1,0 +1,27 @@
+name = "cosign"
+version = "3.0.6"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-linux-amd64"
+sha256 = "c956e5dfcac53d52bcf058360d579472f0c1d2d9b69f55209e256fe7783f4c74"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-linux-arm64"
+sha256 = "bedac92e8c3729864e13d4a17048007cfafa79d5deca993a43a90ffe018ef2b8"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-darwin-amd64"
+sha256 = "4c3e7af8372d3ca3296e62fa56f23fcbb5721cc6ac1827900d398f110d7cd280"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-darwin-arm64"
+sha256 = "5fadd012ae6381a6a29ff86a7d39aa873878852f1073fc90b15995961ecfb084"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-windows-amd64.exe"
+sha256 = "9b85a88ebff2d9dd30ff4984a6f61f2cedc232dd87d81fa7f2ff3c0ed96c241c"

--- a/releases/docker-compose/5.1.3.toml
+++ b/releases/docker-compose/5.1.3.toml
@@ -1,0 +1,32 @@
+name = "docker-compose"
+version = "5.1.3"
+
+[[integrations]]
+kind = "docker_cli_plugin"
+name = "compose"
+source = "artifact.bin"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/docker/compose/releases/download/v5.1.3/docker-compose-linux-x86_64"
+sha256 = "a0298760c9772d2c06888fc8703a487c94c3c3b0134adeef830742a2fc7647b4"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/docker/compose/releases/download/v5.1.3/docker-compose-linux-aarch64"
+sha256 = "e8105a3e687ea7e0b0f81abe4bf9269c8a2801fb72c2b498b5ff2472bc54145f"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/docker/compose/releases/download/v5.1.3/docker-compose-darwin-x86_64"
+sha256 = "f11139d9822ce1f3843e16ed6c2e44ba5525423396c82fa22b08874b26abd102"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/docker/compose/releases/download/v5.1.3/docker-compose-darwin-aarch64"
+sha256 = "b8461a8a53f7e0ce677139516b17661e7ccd54ac4f2dabae03ad79f2f2ae35c6"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/docker/compose/releases/download/v5.1.3/docker-compose-windows-x86_64.exe"
+sha256 = "5e6d72612b3165be9fea4ae889435fec76979a9779b6f62f4efee99dd5f41ea1"

--- a/releases/flux/2.8.6.toml
+++ b/releases/flux/2.8.6.toml
@@ -1,0 +1,32 @@
+name = "flux"
+version = "2.8.6"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/fluxcd/flux2/releases/download/v2.8.6/flux_2.8.6_linux_amd64.tar.gz"
+sha256 = "c53cc990ae266f7840f64c81515d701d8821d558a9062aa4211d71b38cf044be"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/fluxcd/flux2/releases/download/v2.8.6/flux_2.8.6_linux_arm64.tar.gz"
+sha256 = "bc460320c2d33ad833791277896dd1aaf1cff6b3e64ba397c44238f00d4ae5bc"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/fluxcd/flux2/releases/download/v2.8.6/flux_2.8.6_darwin_amd64.tar.gz"
+sha256 = "83ce032f39248ed04324f3e50344794575fb5f7149f24c071972e320b64826a6"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/fluxcd/flux2/releases/download/v2.8.6/flux_2.8.6_darwin_arm64.tar.gz"
+sha256 = "20de67ebf2da689dd165b004dc073469f33aa2a3eac45a69f38a40435e14d20b"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/fluxcd/flux2/releases/download/v2.8.6/flux_2.8.6_windows_amd64.zip"
+sha256 = "05fe1b414bb40555d72e8149aca7046eba4ceacea7825d011c1188cc74c62e9c"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+url = "https://github.com/fluxcd/flux2/releases/download/v2.8.6/flux_2.8.6_windows_arm64.zip"
+sha256 = "8be323b730d1c99977926e12a6d35d32ccfc91cb942e19c282fc7e8a21e4f1ed"

--- a/releases/gum/0.17.0.toml
+++ b/releases/gum/0.17.0.toml
@@ -1,0 +1,27 @@
+name = "gum"
+version = "0.17.0"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/charmbracelet/gum/releases/download/v0.17.0/gum_0.17.0_Linux_x86_64.tar.gz"
+sha256 = "69ee169bd6387331928864e94d47ed01ef649fbfe875baed1bbf27b5377a6fdb"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/charmbracelet/gum/releases/download/v0.17.0/gum_0.17.0_Linux_arm64.tar.gz"
+sha256 = "b0b9ed95cbf7c8b7073f17b9591811f5c001e33c7cfd066ca83ce8a07c576f9c"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/charmbracelet/gum/releases/download/v0.17.0/gum_0.17.0_Darwin_x86_64.tar.gz"
+sha256 = "cd66576aeebe6cd19c771863c7e8d696e0e1d5387d1e7075666baa67c2052e53"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/charmbracelet/gum/releases/download/v0.17.0/gum_0.17.0_Darwin_arm64.tar.gz"
+sha256 = "e2a4b8596efa05821d8c58d0c1afbcd7ad1699ba69c689cc3ff23a4a99c8b237"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/charmbracelet/gum/releases/download/v0.17.0/gum_0.17.0_Windows_x86_64.zip"
+sha256 = "b2be80531c6babc8d4e0e6ca95773d58118a2e1582ae006aace08dbc55503072"

--- a/releases/helix/25.07.1.toml
+++ b/releases/helix/25.07.1.toml
@@ -1,0 +1,27 @@
+name = "helix"
+version = "25.07.1"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/helix-editor/helix/releases/download/25.07.1/helix-25.07.1-x86_64-linux.tar.xz"
+sha256 = "3f08e63ecd388fff657ad39722f88bb03dcf326f1f2da2700d99e1dc40ab2e8b"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/helix-editor/helix/releases/download/25.07.1/helix-25.07.1-aarch64-linux.tar.xz"
+sha256 = "ce23fa8d395e633e3e54c052012f11965d91d8d5c2bfa659685f50430b4f8175"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/helix-editor/helix/releases/download/25.07.1/helix-25.07.1-x86_64-macos.tar.xz"
+sha256 = "84dc32d617d28d32f4aa21e3aafac47bd715d1154aeb977697d4d60b887b7103"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/helix-editor/helix/releases/download/25.07.1/helix-25.07.1-aarch64-macos.tar.xz"
+sha256 = "00b1651b4fdbbe0a2ae981c8e76b858bd26a7c33f5b3583f3b6bb9137d54f1ff"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/helix-editor/helix/releases/download/25.07.1/helix-25.07.1-x86_64-windows.zip"
+sha256 = "5c8325ced8bacd8418d62706f669e96d9c3578a9237526e34d546900cbc049b6"

--- a/releases/helm/4.1.4.toml
+++ b/releases/helm/4.1.4.toml
@@ -1,0 +1,32 @@
+name = "helm"
+version = "4.1.4"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://get.helm.sh/helm-v4.1.4-linux-amd64.tar.gz"
+sha256 = "70b2c30a19da4db264dfd68c8a3664e05093a361cefd89572ffb36f8abfa3d09"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://get.helm.sh/helm-v4.1.4-linux-arm64.tar.gz"
+sha256 = "13d03672be289045d2ff00e4e345d61de1c6f21c1257a45955a30e8ae036d8f1"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://get.helm.sh/helm-v4.1.4-darwin-amd64.tar.gz"
+sha256 = "abf09c8503ad1d8ef76d3737a058c3456a998aae5f5966fce4bb3031aeb1654e"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://get.helm.sh/helm-v4.1.4-darwin-arm64.tar.gz"
+sha256 = "7c2eca678e8001fa863cdf8cbf6ac1b3799f9404a89eb55c08260ef5732e658d"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://get.helm.sh/helm-v4.1.4-windows-amd64.zip"
+sha256 = "bd60f567f667631a2c9b698dfabe5e3cd52eaaf4264163c0a9cae566db8560e8"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+url = "https://get.helm.sh/helm-v4.1.4-windows-arm64.zip"
+sha256 = "d0a651026da4a26b28bdfc3d455ce3dfacbc267182dc2225c2172b1dcc549643"

--- a/releases/k9s/0.50.18.toml
+++ b/releases/k9s/0.50.18.toml
@@ -1,0 +1,32 @@
+name = "k9s"
+version = "0.50.18"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/derailed/k9s/releases/download/v0.50.18/k9s_Linux_amd64.tar.gz"
+sha256 = "0b697ed4aa80997f7de4deeed6f1fba73df191b28bf691b1f28d2f45fa2a9e9b"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/derailed/k9s/releases/download/v0.50.18/k9s_Linux_arm64.tar.gz"
+sha256 = "d3dcc051d6be26ee911c00f583412802ebe203a189e51bc079332cb410c83b38"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/derailed/k9s/releases/download/v0.50.18/k9s_Darwin_amd64.tar.gz"
+sha256 = "80f3e30767ad3603bec9664db019e85f94493aa741d7755553ee6e47876df30e"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/derailed/k9s/releases/download/v0.50.18/k9s_Darwin_arm64.tar.gz"
+sha256 = "68ff1541c60620466989019e86101805c1b6c70a746b1561261a403801f7fd48"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/derailed/k9s/releases/download/v0.50.18/k9s_Windows_amd64.zip"
+sha256 = "9d4e8672c4e55c04cb137475062bc88da7fc0878e04d53df181196449600da16"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+url = "https://github.com/derailed/k9s/releases/download/v0.50.18/k9s_Windows_arm64.zip"
+sha256 = "005bd1a54a52c914eb6cbf29403b572ab48e4345f0cb86614873ff56b9e80b0c"

--- a/releases/kind/0.31.0.toml
+++ b/releases/kind/0.31.0.toml
@@ -1,0 +1,27 @@
+name = "kind"
+version = "0.31.0"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/kubernetes-sigs/kind/releases/download/v0.31.0/kind-linux-amd64"
+sha256 = "eb244cbafcc157dff60cf68693c14c9a75c4e6e6fedaf9cd71c58117cb93e3fa"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/kubernetes-sigs/kind/releases/download/v0.31.0/kind-linux-arm64"
+sha256 = "8e1014e87c34901cc422a1445866835d1e666f2a61301c27e722bdeab5a1f7e4"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/kubernetes-sigs/kind/releases/download/v0.31.0/kind-darwin-amd64"
+sha256 = "a8b3cf77b2ad77aec5bf710d1a2589d9117576132af812885cad41e9dede4d4e"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/kubernetes-sigs/kind/releases/download/v0.31.0/kind-darwin-arm64"
+sha256 = "88bf554fe9da6311c9f8c2d082613c002911a476f6b5090e9420b35d84e70c5c"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/kubernetes-sigs/kind/releases/download/v0.31.0/kind-windows-amd64"
+sha256 = "2c3a9ff954de16244380778683cf99e271bfc2fac9c6c4e797e4623c45e59d9d"

--- a/releases/kubecolor/0.6.0.toml
+++ b/releases/kubecolor/0.6.0.toml
@@ -1,0 +1,32 @@
+name = "kubecolor"
+version = "0.6.0"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/kubecolor/kubecolor/releases/download/v0.6.0/kubecolor_0.6.0_linux_amd64.tar.gz"
+sha256 = "ded167eb2d94145cc46e4ccb52db24e85a865858353014514a85cb59c649d2fe"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/kubecolor/kubecolor/releases/download/v0.6.0/kubecolor_0.6.0_linux_arm64.tar.gz"
+sha256 = "aa56015817bdfe8a8944169e5b18108235fb5bca671f89fa52613b4379bf1f66"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/kubecolor/kubecolor/releases/download/v0.6.0/kubecolor_0.6.0_darwin_amd64.tar.gz"
+sha256 = "8edea5adc6bdb121ec907014790ca780c97aac3766e0c27327227ccc0748c7e4"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/kubecolor/kubecolor/releases/download/v0.6.0/kubecolor_0.6.0_darwin_arm64.tar.gz"
+sha256 = "22f08853f8925613f1792dd5acaaf0661284bb647d69ff50ad9552027b0d456a"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/kubecolor/kubecolor/releases/download/v0.6.0/kubecolor_0.6.0_windows_amd64.zip"
+sha256 = "00828c48ddd123a5cade6da6c13d3a6e5499ed9ba49645aa59ec9b0ac6fe6150"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+url = "https://github.com/kubecolor/kubecolor/releases/download/v0.6.0/kubecolor_0.6.0_windows_arm64.zip"
+sha256 = "4b88981e9dad7679bbb32d971389ea45ae0ad3a0738f78211fb4923ac73f76a4"

--- a/releases/kubectx/0.11.0.toml
+++ b/releases/kubectx/0.11.0.toml
@@ -1,0 +1,33 @@
+name = "kubectx"
+version = "0.11.0"
+
+[[integrations]]
+kind = "path_plugin"
+host = "kubectl"
+name = "ctx"
+source = "kubectx"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/ahmetb/kubectx/releases/download/v0.11.0/kubectx_v0.11.0_linux_x86_64.tar.gz"
+sha256 = "08e031c54fbffb3f100e904e4eae94bba2730fedf4869921fda79e4d7a8f5d4c"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/ahmetb/kubectx/releases/download/v0.11.0/kubectx_v0.11.0_linux_arm64.tar.gz"
+sha256 = "1dac2072216689e773325cb7587b858ea7415706ebcf04e23bf80e7e70555340"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/ahmetb/kubectx/releases/download/v0.11.0/kubectx_v0.11.0_darwin_x86_64.tar.gz"
+sha256 = "80097893b478c55be51ffe826c172f0fd5095d23cca02adbcbcabc412700a689"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/ahmetb/kubectx/releases/download/v0.11.0/kubectx_v0.11.0_darwin_arm64.tar.gz"
+sha256 = "b8c9b5150ca6d902474a115cf7e535831081b9ae10cbe561ea36c82bb3823d02"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/ahmetb/kubectx/releases/download/v0.11.0/kubectx_v0.11.0_windows_x86_64.zip"
+sha256 = "a28fc2f0c69e715c34ea6d7520b9a17aa00cea642ff6fab0c64614d436d47a5d"

--- a/releases/kustomize/5.8.1.toml
+++ b/releases/kustomize/5.8.1.toml
@@ -1,0 +1,32 @@
+name = "kustomize"
+version = "5.8.1"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v5.8.1/kustomize_v5.8.1_linux_amd64.tar.gz"
+sha256 = "029a7f0f4e1932c52a0476cf02a0fd855c0bb85694b82c338fc648dcb53a819d"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v5.8.1/kustomize_v5.8.1_linux_arm64.tar.gz"
+sha256 = "0953ea3e476f66d6ddfcd911d750f5167b9365aa9491b2326398e289fef2c142"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v5.8.1/kustomize_v5.8.1_darwin_amd64.tar.gz"
+sha256 = "ee7cf0c1e3592aa7bb66ba82b359933a95e7f2e0b36e5f53ed0a4535b017f2f8"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v5.8.1/kustomize_v5.8.1_darwin_arm64.tar.gz"
+sha256 = "8886f8a78474e608cc81234f729fda188a9767da23e28925802f00ece2bab288"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v5.8.1/kustomize_v5.8.1_windows_amd64.zip"
+sha256 = "8ec7f5e815e526d4622c06df0a7793d8cfb6eb1c74f816b46166097fef8b26c6"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+url = "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v5.8.1/kustomize_v5.8.1_windows_arm64.zip"
+sha256 = "f6f5090c373965760a30a59af84c81853b80d2c7dbb3236424f440e47eed3f5a"

--- a/releases/lazydocker/0.25.2.toml
+++ b/releases/lazydocker/0.25.2.toml
@@ -1,0 +1,32 @@
+name = "lazydocker"
+version = "0.25.2"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/jesseduffield/lazydocker/releases/download/v0.25.2/lazydocker_0.25.2_Linux_x86_64.tar.gz"
+sha256 = "0d9dbfc26068b218e7ed84b104748cadc6e3cf733c0afd35465306fb39b9523c"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/jesseduffield/lazydocker/releases/download/v0.25.2/lazydocker_0.25.2_Linux_arm64.tar.gz"
+sha256 = "005c38b685aaa557e7d646d83a3dadb5024340eeed8c6a2e1949eee6f530de23"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/jesseduffield/lazydocker/releases/download/v0.25.2/lazydocker_0.25.2_Darwin_x86_64.tar.gz"
+sha256 = "af70b6e234089aa24924db25fc201d17f224e76d334e743e4595d30cf83a013b"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/jesseduffield/lazydocker/releases/download/v0.25.2/lazydocker_0.25.2_Darwin_arm64.tar.gz"
+sha256 = "4a54d7b4abdf255b2bce9806641eac5568d5b7fbc820c1b5d3f9e34ea1367d60"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/jesseduffield/lazydocker/releases/download/v0.25.2/lazydocker_0.25.2_Windows_x86_64.zip"
+sha256 = "facae8869c1bf144468191c563002162273a2c2761f052659170530cae3fa8a9"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+url = "https://github.com/jesseduffield/lazydocker/releases/download/v0.25.2/lazydocker_0.25.2_Windows_arm64.zip"
+sha256 = "25a4f4708b7f73a0aeadde13c8d7a172baa5a1ebabccb062765c28ae93029903"

--- a/releases/minikube/1.38.1.toml
+++ b/releases/minikube/1.38.1.toml
@@ -1,0 +1,27 @@
+name = "minikube"
+version = "1.38.1"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/kubernetes/minikube/releases/download/v1.38.1/minikube-linux-amd64"
+sha256 = "099477eaf248bcb5bcea8ce78a2898e93ac01461c35189da1848c3de82ecd22e"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/kubernetes/minikube/releases/download/v1.38.1/minikube-linux-arm64"
+sha256 = "a0b8a1ebfc8c07a247271d8df98ac0ddd7c8c855b601d402463e2e50c08c6bab"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/kubernetes/minikube/releases/download/v1.38.1/minikube-darwin-amd64"
+sha256 = "db11dffba835609988e4e98c3a91a38653ce66ddfa8ea3aaea92d87c54a0a348"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/kubernetes/minikube/releases/download/v1.38.1/minikube-darwin-arm64"
+sha256 = "f9b0c70bb7daf38c683c0b6e46dc1b612600247ae826bf74576807746a919ee8"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/kubernetes/minikube/releases/download/v1.38.1/minikube-windows-amd64.exe"
+sha256 = "04215bec5632a976b48eb632856b50f1eaaa183b9c2a5904e11d1bacc4961ff7"

--- a/releases/oras/1.3.2.toml
+++ b/releases/oras/1.3.2.toml
@@ -1,0 +1,27 @@
+name = "oras"
+version = "1.3.2"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/oras-project/oras/releases/download/v1.3.2/oras_1.3.2_linux_amd64.tar.gz"
+sha256 = "9229ccc6d17bb282039ad4a69abb16dcb887a5bce567c075d731d9b3c7ad8eaf"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/oras-project/oras/releases/download/v1.3.2/oras_1.3.2_linux_arm64.tar.gz"
+sha256 = "8db4a223bd6034deff198e791ea7cb3af0840df25b7e9f370e2f1f3fd20d389b"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/oras-project/oras/releases/download/v1.3.2/oras_1.3.2_darwin_amd64.tar.gz"
+sha256 = "2621f6b252b222f6fbf4e114d2fcaa0cec6b632624ffaf73143f66e4e0994f86"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/oras-project/oras/releases/download/v1.3.2/oras_1.3.2_darwin_arm64.tar.gz"
+sha256 = "7929f792cf272268412375ecad6f0fb3c20f164368d5b57966e67ad6d36eca53"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/oras-project/oras/releases/download/v1.3.2/oras_1.3.2_windows_amd64.zip"
+sha256 = "c896f26245f11e6385d52010bb0a65a4e500e1f3244680a6556ed05462fa1c0d"

--- a/releases/sops/3.12.2.toml
+++ b/releases/sops/3.12.2.toml
@@ -1,0 +1,32 @@
+name = "sops"
+version = "3.12.2"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/getsops/sops/releases/download/v3.12.2/sops-v3.12.2.linux.amd64"
+sha256 = "14e2e1ba3bef31e74b70cf0b674f6443c80f6c5f3df15d05ffc57c34851b4998"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/getsops/sops/releases/download/v3.12.2/sops-v3.12.2.linux.arm64"
+sha256 = "f66de6f528dca946e910d74fa36a62a7714c11d0db16bd3c9bd8acf73b66704b"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/getsops/sops/releases/download/v3.12.2/sops-v3.12.2.darwin.amd64"
+sha256 = "767c0dcb42e052fd6f2ac17d4473eca6f5fc4910e2b70127f1308d86c606c022"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/getsops/sops/releases/download/v3.12.2/sops-v3.12.2.darwin.arm64"
+sha256 = "284edc64acf91ca249f227ffa2b444632656e4e1ac02baa26bed7051a7d51ce5"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/getsops/sops/releases/download/v3.12.2/sops-v3.12.2.amd64.exe"
+sha256 = "5e777b1854ab2a6271d8f66375970e1fe3eea838251c309de151d16a2bdf13a2"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+url = "https://github.com/getsops/sops/releases/download/v3.12.2/sops-v3.12.2.arm64.exe"
+sha256 = "bfc95ce0426e78a9dd13a8ef32db61b0587f45660530cb00adcdd374ba84fd9e"

--- a/releases/syncthing/2.0.16.toml
+++ b/releases/syncthing/2.0.16.toml
@@ -1,0 +1,18 @@
+name = "syncthing"
+version = "2.0.16"
+
+[[integrations]]
+kind = "service"
+name = "syncthing"
+source = "etc/linux-systemd/system/syncthing.service"
+enable = false
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/syncthing/syncthing/releases/download/v2.0.16/syncthing-linux-amd64-v2.0.16.tar.gz"
+sha256 = "d5ca379993844b0e6e4fced05e3ac4a6c4513dee916ab65516c6d07d5e53e317"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/syncthing/syncthing/releases/download/v2.0.16/syncthing-linux-arm64-v2.0.16.tar.gz"
+sha256 = "0254442af9be1886a7b55f63ad3c24c32fc2e294a3a2efd75a3b8b00335e5bd7"

--- a/releases/trivy/0.70.0.toml
+++ b/releases/trivy/0.70.0.toml
@@ -1,0 +1,27 @@
+name = "trivy"
+version = "0.70.0"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/aquasecurity/trivy/releases/download/v0.70.0/trivy_0.70.0_Linux-64bit.tar.gz"
+sha256 = "8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/aquasecurity/trivy/releases/download/v0.70.0/trivy_0.70.0_Linux-ARM64.tar.gz"
+sha256 = "2f6bb988b553a1bbac6bdd1ce890f5e412439564e17522b88a4541b4f364fc8d"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/aquasecurity/trivy/releases/download/v0.70.0/trivy_0.70.0_macOS-64bit.tar.gz"
+sha256 = "52d531452b19e7593da29366007d02a810e1e0080d02f9cf6a1afb46c35aaa93"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/aquasecurity/trivy/releases/download/v0.70.0/trivy_0.70.0_macOS-ARM64.tar.gz"
+sha256 = "68e543c51dcc96e1c344053a4fde9660cf602c25565d9f09dc17dd41e13b838a"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/aquasecurity/trivy/releases/download/v0.70.0/trivy_0.70.0_windows-64bit.zip"
+sha256 = "eea5442eab86f9e26cd718d7618d43899e72a83767619e8bee47911bddbfb825"

--- a/scripts/registry-generate-manifest.py
+++ b/scripts/registry-generate-manifest.py
@@ -93,6 +93,14 @@ def _render_artifact_templates(chunks: list[str], artifacts: list[dict]) -> None
             chunks.append("")
 
 
+def _render_integrations(chunks: list[str], integrations: list[dict]) -> None:
+    for integration in integrations:
+        chunks.append("[[integrations]]")
+        for key, value in integration.items():
+            chunks.append(_line(key, value))
+        chunks.append("")
+
+
 def render_package_text(doc: dict) -> str:
     chunks: list[str] = []
     chunks.append(_line("name", doc["name"]))
@@ -103,6 +111,12 @@ def render_package_text(doc: dict) -> str:
     source = doc.get("source")
     if isinstance(source, dict):
         render_source_text(chunks, source)
+
+    integrations = doc.get("integrations", [])
+    if integrations:
+        if not isinstance(integrations, list):
+            raise GenerateError("integrations must be an array")
+        _render_integrations(chunks, integrations)
 
     artifacts = doc.get("artifacts")
     if not isinstance(artifacts, list) or not artifacts:
@@ -117,6 +131,12 @@ def render_release_text(doc: dict) -> str:
     chunks.append(_line("name", doc["name"]))
     chunks.append(_line("version", doc["version"]))
     chunks.append("")
+
+    integrations = doc.get("integrations", [])
+    if integrations:
+        if not isinstance(integrations, list):
+            raise GenerateError("integrations must be an array")
+        _render_integrations(chunks, integrations)
 
     for artifact in doc["artifacts"]:
         chunks.append("[[artifacts]]")
@@ -443,6 +463,7 @@ def generate_release_text(
     document = {
         "name": config["name"],
         "version": version,
+        "integrations": config.get("integrations", []),
         "artifacts": release_artifacts,
     }
     return render_release_text(document)

--- a/scripts/registry-validate-source.py
+++ b/scripts/registry-validate-source.py
@@ -27,6 +27,7 @@ RELEASE_KIND_VALUES = {
 VERSION_KIND_VALUES = {"asset_name_regex", "github_tag", "prefixed_semver_field", "regex_capture", "semver_field"}
 CHECKSUM_KIND_VALUES = {"asset_digest", "download_sha256", "download_index", "shasums256", "url_sha256"}
 ASSET_KIND_VALUES = {"json_index_asset", "release_asset_url", "templated"}
+INTEGRATION_KIND_VALUES = {"docker_cli_plugin", "path_plugin", "service"}
 
 
 def _expect_non_empty_str(obj: dict, key: str, ctx: str) -> str:
@@ -55,6 +56,40 @@ def _expect_optional_str_array(obj: dict, key: str, ctx: str) -> None:
     value = obj[key]
     if not isinstance(value, list) or not all(isinstance(item, str) and item for item in value):
         raise ValidationError(f"{ctx}.{key} must be a string array")
+
+
+def _is_relative_without_parent_segments(value: str) -> bool:
+    candidate = Path(value)
+    return not candidate.is_absolute() and ".." not in candidate.parts
+
+
+def _validate_integrations(doc: dict) -> None:
+    integrations = doc.get("integrations", [])
+    if not isinstance(integrations, list):
+        raise ValidationError("manifest.integrations must be an array when present")
+
+    seen: set[str] = set()
+    for idx, integration in enumerate(integrations, start=1):
+        if not isinstance(integration, dict):
+            raise ValidationError(f"manifest.integrations[{idx}] must be a table")
+        prefix = f"manifest.integrations[{idx}]"
+        kind = _expect_non_empty_str(integration, "kind", prefix)
+        if kind not in INTEGRATION_KIND_VALUES:
+            raise ValidationError(f"{prefix}.kind must be a supported integration kind")
+        source = _expect_non_empty_str(integration, "source", prefix)
+        if not _is_relative_without_parent_segments(source):
+            raise ValidationError(f"{prefix}.source must be relative and must not contain '..'")
+        name = _expect_non_empty_str(integration, "name", prefix)
+        if kind == "path_plugin":
+            host = _expect_non_empty_str(integration, "host", prefix)
+            key = f"{kind}:{host}:{name}"
+        else:
+            key = f"{kind}:{name}"
+        if kind == "service":
+            _expect_optional_bool(integration, "enable", prefix)
+        if key in seen:
+            raise ValidationError(f"duplicate integration declaration {key}")
+        seen.add(key)
 
 
 def validate_source_config(doc: dict) -> None:
@@ -182,6 +217,8 @@ def validate_source_config(doc: dict) -> None:
         tag_prefix = source.get("tag_prefix")
         if tag_prefix is not None and not isinstance(tag_prefix, str):
             raise ValidationError("manifest.source.tag_prefix must be a string")
+
+    _validate_integrations(doc)
 
     artifacts = doc.get("artifacts")
     if not isinstance(artifacts, list) or not artifacts:

--- a/scripts/registry-validate.py
+++ b/scripts/registry-validate.py
@@ -21,6 +21,7 @@ RELEASE_KIND_VALUES = {
 VERSION_KIND_VALUES = {"asset_name_regex", "github_tag", "prefixed_semver_field", "regex_capture", "semver_field"}
 CHECKSUM_KIND_VALUES = {"asset_digest", "download_sha256", "download_index", "shasums256", "url_sha256"}
 ASSET_KIND_VALUES = {"json_index_asset", "release_asset_url", "templated"}
+INTEGRATION_KIND_VALUES = {"docker_cli_plugin", "path_plugin", "service"}
 
 
 def err(errors: list[str], path: Path, message: str) -> None:
@@ -73,6 +74,48 @@ def validate_common_artifact_template_fields(
         err(errors, path, f"{prefix}.strip_components must be an integer >= 0")
 
 
+def validate_integrations(path: Path, doc: dict, errors: list[str]) -> None:
+    integrations = doc.get("integrations", [])
+    if not isinstance(integrations, list):
+        err(errors, path, "integrations must be an array when present")
+        return
+
+    seen: set[str] = set()
+    for idx, integration in enumerate(integrations, start=1):
+        prefix = f"integrations[{idx}]"
+        if not isinstance(integration, dict):
+            err(errors, path, f"{prefix} must be a table")
+            continue
+        kind = integration.get("kind")
+        if not isinstance(kind, str) or kind not in INTEGRATION_KIND_VALUES:
+            err(errors, path, f"{prefix}.kind must be a supported integration kind")
+            continue
+        source = integration.get("source")
+        if not isinstance(source, str) or not source.strip():
+            err(errors, path, f"{prefix}.source must be a non-empty string")
+        elif not is_relative_without_parent_segments(source):
+            err(errors, path, f"{prefix}.source must be relative and must not contain '..'")
+        name = integration.get("name")
+        if not isinstance(name, str) or not name.strip():
+            err(errors, path, f"{prefix}.name must be a non-empty string")
+            continue
+        if kind == "path_plugin":
+            host = integration.get("host")
+            if not isinstance(host, str) or not host.strip():
+                err(errors, path, f"{prefix}.host must be a non-empty string")
+                continue
+            key = f"{kind}:{host}:{name}"
+        else:
+            key = f"{kind}:{name}"
+        if kind == "service":
+            enable = integration.get("enable")
+            if enable is not None and not isinstance(enable, bool):
+                err(errors, path, f"{prefix}.enable must be a boolean when present")
+        if key in seen:
+            err(errors, path, f"duplicate integration declaration `{key}`")
+        seen.add(key)
+
+
 def validate_package_manifest(path: Path, doc: dict, errors: list[str]) -> None:
     name_ok = expect_nonempty_str(doc.get("name"), "name", errors, path)
     expect_nonempty_str(doc.get("license"), "license", errors, path)
@@ -80,6 +123,8 @@ def validate_package_manifest(path: Path, doc: dict, errors: list[str]) -> None:
 
     if homepage_ok and not str(doc["homepage"]).startswith("https://"):
         err(errors, path, "invalid `homepage` (must start with https://)")
+
+    validate_integrations(path, doc, errors)
 
     source = doc.get("source")
     if not isinstance(source, dict):
@@ -356,6 +401,8 @@ def validate_package_manifest(path: Path, doc: dict, errors: list[str]) -> None:
 def validate_release_manifest(path: Path, doc: dict, errors: list[str]) -> None:
     name_ok = expect_nonempty_str(doc.get("name"), "name", errors, path)
     version_ok = expect_nonempty_str(doc.get("version"), "version", errors, path)
+
+    validate_integrations(path, doc, errors)
 
     if version_ok and not SEMVER_RE.fullmatch(str(doc["version"])):
         err(

--- a/tests/test_registry_generate_manifest.py
+++ b/tests/test_registry_generate_manifest.py
@@ -158,6 +158,55 @@ class RegistryGenerateManifestTests(unittest.TestCase):
             self.assertNotIn("license =", rendered)
             self.assertNotIn("homepage =", rendered)
 
+    def test_generates_package_and_release_text_with_integrations(self) -> None:
+        doc = {
+            "name": "kubectx",
+            "license": "Apache-2.0",
+            "homepage": "https://github.com/ahmetb/kubectx",
+            "source": {
+                "release": {"kind": "github_releases", "repo": "ahmetb/kubectx"},
+                "checksum": {"kind": "asset_digest"},
+                "asset": {"kind": "release_asset_url"},
+            },
+            "integrations": [
+                {
+                    "kind": "path_plugin",
+                    "host": "kubectl",
+                    "name": "ctx",
+                    "source": "kubectl-ctx",
+                }
+            ],
+            "artifacts": [
+                {
+                    "target": "x86_64-unknown-linux-gnu",
+                    "asset": "kubectx_v{version}_linux_x86_64.tar.gz",
+                    "archive": "tar.gz",
+                    "strip_components": 0,
+                    "binaries": [{"name": "kubectl-ctx", "path": "kubectx"}],
+                }
+            ],
+        }
+
+        package_text = self.generator.render_package_text(doc)
+        release_text = self.generator.render_release_text(
+            {
+                "name": "kubectx",
+                "version": "0.9.5",
+                "integrations": doc["integrations"],
+                "artifacts": [
+                    {
+                        "target": "x86_64-unknown-linux-gnu",
+                        "url": "https://example.invalid/kubectx.tar.gz",
+                        "sha256": "a" * 64,
+                    }
+                ],
+            }
+        )
+
+        self.assertIn('[[integrations]]\nkind = "path_plugin"', package_text)
+        self.assertIn('host = "kubectl"', package_text)
+        self.assertIn('[[integrations]]\nkind = "path_plugin"', release_text)
+
     def test_download_retries_transient_http_error(self) -> None:
         with tempfile.TemporaryDirectory(prefix="manifest-gen-") as tmp:
             dest = Path(tmp) / "artifact.tar.gz"

--- a/tests/test_registry_validate.py
+++ b/tests/test_registry_validate.py
@@ -25,6 +25,11 @@ class RegistryValidateTests(unittest.TestCase):
                     license = "MIT"
                     homepage = "https://example.com/demo"
 
+                    [[integrations]]
+                    kind = "service"
+                    name = "demo"
+                    source = "etc/systemd/demo.service"
+
                     [source]
                     provider = "github"
                     repo = "example/demo"
@@ -49,6 +54,11 @@ class RegistryValidateTests(unittest.TestCase):
                     """
                     name = "demo"
                     version = "1.2.3"
+
+                    [[integrations]]
+                    kind = "service"
+                    name = "demo"
+                    source = "etc/systemd/demo.service"
 
                     [[artifacts]]
                     target = "x86_64-unknown-linux-gnu"

--- a/tests/test_registry_validate_source.py
+++ b/tests/test_registry_validate_source.py
@@ -104,6 +104,107 @@ class RegistryValidateSourceTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertIn("Validation passed", result.stdout)
 
+    def test_valid_source_config_with_integrations_passes(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="source-config-") as tmp:
+            config = Path(tmp) / "docker-compose.toml"
+            config.write_text(
+                textwrap.dedent(
+                    """
+                    name = "docker-compose"
+                    license = "Apache-2.0"
+                    homepage = "https://github.com/docker/compose"
+
+                    [source.release]
+                    kind = "github_releases"
+                    repo = "docker/compose"
+
+                    [source.checksum]
+                    kind = "asset_digest"
+
+                    [source.asset]
+                    kind = "release_asset_url"
+
+                    [[integrations]]
+                    kind = "docker_cli_plugin"
+                    name = "compose"
+                    source = "docker-compose"
+
+                    [[artifacts]]
+                    target = "x86_64-unknown-linux-gnu"
+                    asset = "docker-compose-linux-x86_64"
+                    archive = "bin"
+                    strip_components = 0
+
+                    [[artifacts.binaries]]
+                    name = "docker-compose"
+                    path = "docker-compose"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                ["python3", str(SCRIPT), str(config)],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+            )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("Validation passed", result.stdout)
+
+    def test_integration_source_path_rejects_parent_segments(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="source-config-") as tmp:
+            config = Path(tmp) / "kubectx.toml"
+            config.write_text(
+                textwrap.dedent(
+                    """
+                    name = "kubectx"
+                    license = "Apache-2.0"
+                    homepage = "https://github.com/ahmetb/kubectx"
+
+                    [source.release]
+                    kind = "github_releases"
+                    repo = "ahmetb/kubectx"
+
+                    [source.checksum]
+                    kind = "asset_digest"
+
+                    [source.asset]
+                    kind = "release_asset_url"
+
+                    [[integrations]]
+                    kind = "path_plugin"
+                    host = "kubectl"
+                    name = "ctx"
+                    source = "../kubectl-ctx"
+
+                    [[artifacts]]
+                    target = "x86_64-unknown-linux-gnu"
+                    asset = "kubectx_v{version}_linux_x86_64.tar.gz"
+                    archive = "tar.gz"
+                    strip_components = 0
+
+                    [[artifacts.binaries]]
+                    name = "kubectl-ctx"
+                    path = "kubectx"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                ["python3", str(SCRIPT), str(config)],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("integrations[1].source", result.stderr)
+
     def test_missing_required_source_fields_fails(self) -> None:
         with tempfile.TemporaryDirectory(prefix="source-config-") as tmp:
             config = Path(tmp) / "ripgrep.toml"


### PR DESCRIPTION
## Summary
- Adds `docker-compose`, `kubectx`, and `syncthing` as examples for Docker CLI plugin, PATH plugin, and service integrations.
- Extends registry package/release generation to preserve root-level `[[integrations]]` metadata.
- Validates integration kind, source paths, and duplicate ownership in package and release manifests.

## Verification
- `python3 -m unittest discover -s tests -v`
- `python3 scripts/registry-validate-source.py packages/*.toml`
- `python3 scripts/registry-validate.py --allow-missing-signatures packages/*.toml releases/docker-compose/5.1.3.toml releases/kubectx/0.11.0.toml releases/syncthing/2.0.16.toml`
- `python3 scripts/registry-smoke-install.py --require-runner-target releases/docker-compose/5.1.3.toml releases/kubectx/0.11.0.toml releases/syncthing/2.0.16.toml`