### PR TITLE
feat(registry): add integration stress package batch

### DIFF
--- a/packages/docker-buildx.toml
+++ b/packages/docker-buildx.toml
@@ -1,0 +1,73 @@
+name = "docker-buildx"
+license = "Apache-2.0"
+homepage = "https://github.com/docker/buildx"
+
+[source.release]
+kind = "github_releases"
+repo = "docker/buildx"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "asset_digest"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[integrations]]
+kind = "docker_cli_plugin"
+name = "buildx"
+source = "artifact.bin"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "buildx-v{version}.linux-amd64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "docker-buildx"
+path = "artifact.bin"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "buildx-v{version}.linux-arm64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "docker-buildx"
+path = "artifact.bin"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "buildx-v{version}.darwin-amd64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "docker-buildx"
+path = "artifact.bin"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "buildx-v{version}.darwin-arm64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "docker-buildx"
+path = "artifact.bin"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "buildx-v{version}.windows-amd64.exe"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "docker-buildx"
+path = "artifact.bin"

--- a/packages/kubelogin.toml
+++ b/packages/kubelogin.toml
@@ -1,0 +1,75 @@
+name = "kubelogin"
+license = "Apache-2.0"
+homepage = "https://github.com/int128/kubelogin"
+
+[source.release]
+kind = "github_releases"
+repo = "int128/kubelogin"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "url_sha256"
+url_template = "{url}.sha256"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[integrations]]
+kind = "path_plugin"
+host = "kubectl"
+name = "oidc-login"
+source = "kubelogin"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "kubelogin_linux_amd64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kubectl-oidc-login"
+path = "kubelogin"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "kubelogin_linux_arm64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kubectl-oidc-login"
+path = "kubelogin"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "kubelogin_darwin_amd64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kubectl-oidc-login"
+path = "kubelogin"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "kubelogin_darwin_arm64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kubectl-oidc-login"
+path = "kubelogin"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "kubelogin_windows_amd64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kubectl-oidc-login"
+path = "kubelogin.exe"

--- a/packages/kubens.toml
+++ b/packages/kubens.toml
@@ -1,0 +1,74 @@
+name = "kubens"
+license = "Apache-2.0"
+homepage = "https://github.com/ahmetb/kubectx"
+
+[source.release]
+kind = "github_releases"
+repo = "ahmetb/kubectx"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "asset_digest"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[integrations]]
+kind = "path_plugin"
+host = "kubectl"
+name = "ns"
+source = "kubens"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "kubens_v{version}_linux_x86_64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kubectl-ns"
+path = "kubens"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "kubens_v{version}_linux_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kubectl-ns"
+path = "kubens"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "kubens_v{version}_darwin_x86_64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kubectl-ns"
+path = "kubens"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "kubens_v{version}_darwin_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kubectl-ns"
+path = "kubens"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "kubens_v{version}_windows_x86_64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "kubectl-ns"
+path = "kubens.exe"

--- a/releases/docker-buildx/0.33.0.toml
+++ b/releases/docker-buildx/0.33.0.toml
@@ -1,0 +1,32 @@
+name = "docker-buildx"
+version = "0.33.0"
+
+[[integrations]]
+kind = "docker_cli_plugin"
+name = "buildx"
+source = "artifact.bin"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/docker/buildx/releases/download/v0.33.0/buildx-v0.33.0.linux-amd64"
+sha256 = "9426a15411f35f635afef3f5d3bae53155c3e30d26dee430cc968e13d34be49f"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/docker/buildx/releases/download/v0.33.0/buildx-v0.33.0.linux-arm64"
+sha256 = "204dc28447d3bb48f42ed1ce5747e0885cd57e306506a39029311becdb1ef786"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/docker/buildx/releases/download/v0.33.0/buildx-v0.33.0.darwin-amd64"
+sha256 = "b1b5a38f78311cfed70a0e68096df0e9ed7dd1b1fcd09adbb117d74e3bad6f32"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/docker/buildx/releases/download/v0.33.0/buildx-v0.33.0.darwin-arm64"
+sha256 = "35dc3303d2ddb20b9490be4f658eb4b08ee6c9b2a5b5a56797f6c8fb20f5f52b"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/docker/buildx/releases/download/v0.33.0/buildx-v0.33.0.windows-amd64.exe"
+sha256 = "832ddf42373203ee3836a7cb3b16fe5080231491e7edb32019ac0f6fe03b99ed"

--- a/releases/kubelogin/1.36.1.toml
+++ b/releases/kubelogin/1.36.1.toml
@@ -1,0 +1,33 @@
+name = "kubelogin"
+version = "1.36.1"
+
+[[integrations]]
+kind = "path_plugin"
+host = "kubectl"
+name = "oidc-login"
+source = "kubelogin"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/int128/kubelogin/releases/download/v1.36.1/kubelogin_linux_amd64.zip"
+sha256 = "a6dae91dfedd564906d892b1bdb1b74d821808802263b95751ca8e95cb1c0936"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/int128/kubelogin/releases/download/v1.36.1/kubelogin_linux_arm64.zip"
+sha256 = "b6790c4991d9ec13fca3c9375635608874434da4a5476b8567e65302c852690e"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/int128/kubelogin/releases/download/v1.36.1/kubelogin_darwin_amd64.zip"
+sha256 = "ab6611b5997bfdd7318cb09bddb8e73445c6ababcacc16d5701c7aa59ad98449"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/int128/kubelogin/releases/download/v1.36.1/kubelogin_darwin_arm64.zip"
+sha256 = "274da7f96172f8b135dc22ce93dd62947bfdec44a2e9554a9111f58c99684f6f"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/int128/kubelogin/releases/download/v1.36.1/kubelogin_windows_amd64.zip"
+sha256 = "0e48b4cc6c0cf6c96e8308f54473ddbcafce037549dce989e3eeecec428bfa32"

--- a/releases/kubens/0.11.0.toml
+++ b/releases/kubens/0.11.0.toml
@@ -1,0 +1,33 @@
+name = "kubens"
+version = "0.11.0"
+
+[[integrations]]
+kind = "path_plugin"
+host = "kubectl"
+name = "ns"
+source = "kubens"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/ahmetb/kubectx/releases/download/v0.11.0/kubens_v0.11.0_linux_x86_64.tar.gz"
+sha256 = "326c021c7b35468ed9a187b361198d0f22ae32828139c65eb6670c0d8301cc09"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/ahmetb/kubectx/releases/download/v0.11.0/kubens_v0.11.0_linux_arm64.tar.gz"
+sha256 = "37058abe82ef20c93b44f3dc8ca2382dbb95d416cec958fbf7b8f79f011be86c"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/ahmetb/kubectx/releases/download/v0.11.0/kubens_v0.11.0_darwin_x86_64.tar.gz"
+sha256 = "9dbe1bf26fd911f2f56661a2f34bf2fe32dfd3af5f11287d0a864da92a746509"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/ahmetb/kubectx/releases/download/v0.11.0/kubens_v0.11.0_darwin_arm64.tar.gz"
+sha256 = "b1c87ddca22f1afc3e980ac807a715cd1183750022798d28a0a4e0cf66bec4e3"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/ahmetb/kubectx/releases/download/v0.11.0/kubens_v0.11.0_windows_x86_64.zip"
+sha256 = "aa10daca6ce321377d61a7e9534911df9eee42a0b6e198000757f8d1e8d0a480"


### PR DESCRIPTION
## Summary
- Add docker-buildx as a Docker CLI plugin integration package.
- Add kubens and kubelogin as kubectl path plugin integration packages.
- Generate release manifests while preserving root-level integration metadata.

## Validation
- python3 scripts/registry-validate-source.py packages/docker-buildx.toml packages/kubens.toml packages/kubelogin.toml
- python3 scripts/registry-validate.py --allow-missing-signatures packages/docker-buildx.toml packages/kubens.toml packages/kubelogin.toml releases/docker-buildx/0.33.0.toml releases/kubens/0.11.0.toml releases/kubelogin/1.36.1.toml
- python3 scripts/registry-smoke-install.py --require-runner-target releases/docker-buildx/0.33.0.toml releases/kubens/0.11.0.toml releases/kubelogin/1.36.1.toml
- python3 -m unittest discover -s tests -v

## Notes
- Rejected krew because its artifact-relative executable path varies by target, while integration source is package-level.
- Rejected caddy and node_exporter service integrations because supported tar/zip artifacts do not include service unit files.
- Root repository submodule bumping is left to automation after merge.