### PR TITLE
fix(registry): cache upstream release checks

### DIFF
--- a/scripts/upstream-release-bot.py
+++ b/scripts/upstream-release-bot.py
@@ -152,9 +152,13 @@ def _http_error_body(error: urllib.error.HTTPError) -> str:
         return ""
 
 
-def _is_rate_limit_error(error: urllib.error.HTTPError) -> bool:
+def _is_skippable_release_fetch_error(
+    *, error: urllib.error.HTTPError, release_kind: object
+) -> bool:
     if error.code != 403:
         return False
+    if release_kind == "github_releases":
+        return True
     reason = str(error.reason).lower()
     if "rate limit" in reason:
         return True
@@ -585,7 +589,9 @@ def main(argv: list[str]) -> int:
             else:
                 raise RuntimeError(f"Unsupported source.release.kind in {config_path}")
         except urllib.error.HTTPError as error:
-            if not _is_rate_limit_error(error):
+            if not _is_skippable_release_fetch_error(
+                error=error, release_kind=release_kind
+            ):
                 raise
             skipped_fetches += 1
             print(

--- a/scripts/upstream-release-bot.py
+++ b/scripts/upstream-release-bot.py
@@ -137,6 +137,34 @@ def fetch_github_releases(repo: str, token: str | None = None) -> list[dict]:
     return [item for item in payload if isinstance(item, dict)]
 
 
+def _format_fetch_error(error: urllib.error.HTTPError | urllib.error.URLError) -> str:
+    if isinstance(error, urllib.error.HTTPError):
+        return f"HTTP {error.code} {error.reason}"
+    return str(error.reason)
+
+
+def _http_error_body(error: urllib.error.HTTPError) -> str:
+    if error.fp is None:
+        return ""
+    try:
+        return error.fp.read().decode("utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def _is_rate_limit_error(error: urllib.error.HTTPError) -> bool:
+    if error.code != 403:
+        return False
+    reason = str(error.reason).lower()
+    if "rate limit" in reason:
+        return True
+    remaining = error.headers.get("x-ratelimit-remaining") if error.headers else None
+    if remaining == "0":
+        return True
+    body = _http_error_body(error).lower()
+    return "rate limit" in body
+
+
 def fetch_json_index_releases(release_strategy: dict) -> list[dict]:
     url = release_strategy.get("url")
     if not isinstance(url, str) or not url.startswith("https://"):
@@ -535,6 +563,7 @@ def main(argv: list[str]) -> int:
 
     github_token = __import__("os").environ.get("GITHUB_TOKEN")
     planned: list[PlannedUpdate] = []
+    skipped_fetches = 0
     for config_path in config_paths:
         config = load_config(config_path)
         source = config.get("source")
@@ -543,17 +572,28 @@ def main(argv: list[str]) -> int:
         normalized = normalize_source(source)
         release_strategy = normalized["release"]
         release_kind = release_strategy.get("kind")
-        if release_kind == "json_index":
-            releases = fetch_json_index_releases(release_strategy)
-        elif release_kind == "text_endpoint":
-            releases = fetch_text_endpoint_releases(release_strategy)
-        elif release_kind == "github_releases":
-            repo = release_strategy.get("repo")
-            if not isinstance(repo, str):
-                raise RuntimeError(f"Missing source.release.repo in {config_path}")
-            releases = fetch_github_releases(repo, token=github_token)
-        else:
-            raise RuntimeError(f"Unsupported source.release.kind in {config_path}")
+        try:
+            if release_kind == "json_index":
+                releases = fetch_json_index_releases(release_strategy)
+            elif release_kind == "text_endpoint":
+                releases = fetch_text_endpoint_releases(release_strategy)
+            elif release_kind == "github_releases":
+                repo = release_strategy.get("repo")
+                if not isinstance(repo, str):
+                    raise RuntimeError(f"Missing source.release.repo in {config_path}")
+                releases = fetch_github_releases(repo, token=github_token)
+            else:
+                raise RuntimeError(f"Unsupported source.release.kind in {config_path}")
+        except urllib.error.HTTPError as error:
+            if not _is_rate_limit_error(error):
+                raise
+            skipped_fetches += 1
+            print(
+                f"Skipping {config_path.stem}: failed to fetch upstream releases "
+                f"({_format_fetch_error(error)})",
+                file=sys.stderr,
+            )
+            continue
         planned.extend(
             plan_updates_for_config(
                 config_path=config_path,
@@ -563,7 +603,10 @@ def main(argv: list[str]) -> int:
         )
 
     if not planned:
-        print("No new releases detected")
+        print(
+            "No new releases detected; "
+            f"skipped {skipped_fetches} release fetch(es)"
+        )
         return 0
 
     created_releases = 0
@@ -642,7 +685,9 @@ def main(argv: list[str]) -> int:
     print(
         "Planned "
         f"{len(planned)} update(s), wrote {created_releases} release manifest(s), "
-        f"updated {written_packages} package template(s), skipped {skipped_updates} incomplete update(s)"
+        f"updated {written_packages} package template(s), "
+        f"skipped {skipped_updates} incomplete update(s), "
+        f"skipped {skipped_fetches} release fetch(es)"
     )
     return 0
 

--- a/scripts/upstream-release-bot.py
+++ b/scripts/upstream-release-bot.py
@@ -10,7 +10,10 @@ import sys
 import time
 import urllib.error
 import urllib.request
+from datetime import datetime, timezone
+from email.message import Message
 from pathlib import Path
+from typing import Any
 
 try:
     import tomllib
@@ -19,6 +22,7 @@ except ModuleNotFoundError:
 
 
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
+STATE_SCHEMA_VERSION = 1
 
 
 class PlannedUpdate:
@@ -27,6 +31,21 @@ class PlannedUpdate:
         self.version = version
         self.config_path = config_path
         self.release = release
+
+
+class GithubReleaseFetchResult:
+    def __init__(
+        self,
+        *,
+        releases: list[dict],
+        etag: str | None = None,
+        last_modified: str | None = None,
+        not_modified: bool = False,
+    ):
+        self.releases = releases
+        self.etag = etag
+        self.last_modified = last_modified
+        self.not_modified = not_modified
 
 
 def normalize_source(source: dict) -> dict:
@@ -99,20 +118,78 @@ def _load_generator_module(repo_root: Path):
     return module
 
 
-def _http_get_json(url: str, token: str | None = None) -> object:
+def empty_bot_state() -> dict[str, Any]:
+    return {"schema_version": STATE_SCHEMA_VERSION, "sources": {}}
+
+
+def load_bot_state(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return empty_bot_state()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"Ignoring invalid release bot state at {path}: {exc}", file=sys.stderr)
+        return empty_bot_state()
+    if not isinstance(data, dict) or data.get("schema_version") != STATE_SCHEMA_VERSION:
+        print(f"Ignoring unsupported release bot state at {path}", file=sys.stderr)
+        return empty_bot_state()
+    sources = data.get("sources")
+    if not isinstance(sources, dict):
+        print(
+            f"Ignoring invalid release bot state at {path}: sources must be an object",
+            file=sys.stderr,
+        )
+        return empty_bot_state()
+    normalized_sources = {
+        key: value
+        for key, value in sources.items()
+        if isinstance(key, str) and isinstance(value, dict)
+    }
+    return {"schema_version": STATE_SCHEMA_VERSION, "sources": normalized_sources}
+
+
+def write_bot_state(path: Path, state: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    sources = state.get("sources")
+    if not isinstance(sources, dict):
+        sources = {}
+    normalized = {
+        "schema_version": STATE_SCHEMA_VERSION,
+        "sources": dict(sorted(sources.items())),
+    }
+    path.write_text(
+        json.dumps(normalized, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def github_release_state_key(repo: str) -> str:
+    return f"github_releases:{repo}"
+
+
+def _http_get_json(
+    url: str,
+    token: str | None = None,
+    extra_headers: dict[str, str] | None = None,
+) -> tuple[object, Message]:
     headers = {
         "Accept": "application/vnd.github+json",
         "User-Agent": "crosspack-registry-upstream-bot",
     }
     if token:
         headers["Authorization"] = f"Bearer {token}"
+    if extra_headers:
+        headers.update(extra_headers)
 
     last_error: Exception | None = None
     for attempt in range(3):
         request = urllib.request.Request(url, headers=headers)
         try:
             with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
-                return json.loads(response.read().decode("utf-8"))
+                return json.loads(response.read().decode("utf-8")), response.headers
         except urllib.error.HTTPError as error:
             if error.code < 500 or attempt == 2:
                 raise
@@ -129,12 +206,35 @@ def _http_get_json(url: str, token: str | None = None) -> object:
     raise RuntimeError(f"Failed to fetch JSON from {url}")
 
 
-def fetch_github_releases(repo: str, token: str | None = None) -> list[dict]:
+def fetch_github_releases(
+    repo: str,
+    token: str | None = None,
+    state_entry: dict[str, Any] | None = None,
+) -> GithubReleaseFetchResult:
     url = f"https://api.github.com/repos/{repo}/releases?per_page=20"
-    payload = _http_get_json(url, token=token)
+    extra_headers: dict[str, str] = {}
+    if isinstance(state_entry, dict):
+        etag = state_entry.get("etag")
+        last_modified = state_entry.get("last_modified")
+        if isinstance(etag, str) and etag:
+            extra_headers["If-None-Match"] = etag
+        if isinstance(last_modified, str) and last_modified:
+            extra_headers["If-Modified-Since"] = last_modified
+    try:
+        payload, headers = _http_get_json(
+            url, token=token, extra_headers=extra_headers
+        )
+    except urllib.error.HTTPError as error:
+        if error.code == 304:
+            return GithubReleaseFetchResult(releases=[], not_modified=True)
+        raise
     if not isinstance(payload, list):
         raise RuntimeError(f"Unexpected releases response for {repo}")
-    return [item for item in payload if isinstance(item, dict)]
+    return GithubReleaseFetchResult(
+        releases=[item for item in payload if isinstance(item, dict)],
+        etag=headers.get("ETag"),
+        last_modified=headers.get("Last-Modified"),
+    )
 
 
 def _format_fetch_error(error: urllib.error.HTTPError | urllib.error.URLError) -> str:
@@ -173,7 +273,7 @@ def fetch_json_index_releases(release_strategy: dict) -> list[dict]:
     url = release_strategy.get("url")
     if not isinstance(url, str) or not url.startswith("https://"):
         raise RuntimeError("json_index release.url must start with https://")
-    payload = _http_get_json(url)
+    payload, _headers = _http_get_json(url)
     entries = release_strategy.get("entries", "array")
     if entries == "array":
         if not isinstance(payload, list):
@@ -342,6 +442,21 @@ def version_from_strategy(release: dict, strategy: dict, release_strategy: dict)
     raise RuntimeError("source.version.kind must be a supported version strategy")
 
 
+def latest_version_from_releases(
+    releases: list[dict], release_strategy: dict, version_strategy: dict
+) -> str | None:
+    include_prereleases = bool(release_strategy.get("include_prereleases", False))
+    for release in releases:
+        if release.get("draft") is True:
+            continue
+        if release.get("prerelease") is True and not include_prereleases:
+            continue
+        version = version_from_strategy(release, version_strategy, release_strategy)
+        if version is not None:
+            return version
+    return None
+
+
 def load_config(path: Path) -> dict:
     data = tomllib.loads(path.read_text(encoding="utf-8"))
     if not isinstance(data, dict):
@@ -394,6 +509,64 @@ def plan_updates_for_config(
 
 def _run(cmd: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(cmd, cwd=cwd, check=True, text=True, capture_output=True)
+
+
+def validate_generated_paths(*, repo_root: Path, staged_paths: list[Path]) -> None:
+    package_paths: list[str] = []
+    release_paths: list[str] = []
+    state_path = Path("state/upstream-release-bot.json")
+    for path in staged_paths:
+        value = path.as_posix()
+        if value.startswith("packages/") and value.endswith(".toml") and len(path.parts) == 2:
+            package_paths.append(value)
+        elif value.startswith("releases/") and value.endswith(".toml") and len(path.parts) == 3:
+            release_paths.append(value)
+        elif path == state_path:
+            continue
+        else:
+            raise RuntimeError(f"unexpected generated path for release bot PR: {value}")
+
+    if package_paths:
+        _run(["python3", "scripts/registry-validate-source.py", *package_paths], cwd=repo_root)
+    if package_paths or release_paths:
+        _run(
+            [
+                "python3",
+                "scripts/registry-validate.py",
+                "--allow-missing-signatures",
+                *package_paths,
+                *release_paths,
+            ],
+            cwd=repo_root,
+        )
+
+
+def _enable_pr_automerge(*, repo_root: Path, pr_ref: str) -> None:
+    _run(["gh", "pr", "merge", pr_ref, "--auto", "--squash"], cwd=repo_root)
+
+
+def _open_pr_number_for_branch(*, repo_root: Path, branch_name: str) -> int | None:
+    existing = _run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--head",
+            branch_name,
+            "--state",
+            "open",
+            "--json",
+            "number",
+        ],
+        cwd=repo_root,
+    )
+    found = json.loads(existing.stdout)
+    if not isinstance(found, list) or not found:
+        return None
+    number = found[0].get("number")
+    if not isinstance(number, int):
+        raise RuntimeError(f"Unexpected PR lookup response for {branch_name}")
+    return number
 
 
 def _stash_paths_for_branch_switch(*, repo_root: Path, paths: list[Path]) -> str | None:
@@ -480,30 +653,22 @@ def _open_or_update_pr(
         _run(["git", "switch", "-C", branch_name, base_branch], cwd=repo_root)
     if staged_paths:
         _run(["git", "add", *(str(path) for path in staged_paths)], cwd=repo_root)
+    validate_generated_paths(repo_root=repo_root, staged_paths=staged_paths)
     staged = _run(["git", "diff", "--cached", "--name-only"], cwd=repo_root)
     if not staged.stdout.strip():
+        number = _open_pr_number_for_branch(repo_root=repo_root, branch_name=branch_name)
+        if number is not None:
+            _enable_pr_automerge(repo_root=repo_root, pr_ref=str(number))
+            print(f"PR already open for {branch_name}; enabled automerge")
         return
 
     _run(["git", "commit", "-m", title], cwd=repo_root)
     _run(["git", "push", "-u", "origin", branch_name], cwd=repo_root)
 
-    existing = _run(
-        [
-            "gh",
-            "pr",
-            "list",
-            "--head",
-            branch_name,
-            "--state",
-            "open",
-            "--json",
-            "number",
-        ],
-        cwd=repo_root,
-    )
-    found = json.loads(existing.stdout)
-    if isinstance(found, list) and found:
-        print(f"PR already open for {branch_name}")
+    number = _open_pr_number_for_branch(repo_root=repo_root, branch_name=branch_name)
+    if number is not None:
+        _enable_pr_automerge(repo_root=repo_root, pr_ref=str(number))
+        print(f"PR already open for {branch_name}; enabled automerge")
         return
 
     _run(
@@ -522,6 +687,7 @@ def _open_or_update_pr(
         ],
         cwd=repo_root,
     )
+    _enable_pr_automerge(repo_root=repo_root, pr_ref=branch_name)
 
 
 def main(argv: list[str]) -> int:
@@ -551,6 +717,12 @@ def main(argv: list[str]) -> int:
     )
     parser.add_argument("--base-branch", default="main")
     parser.add_argument("--branch-prefix", default="upstream-release")
+    parser.add_argument(
+        "--state-path",
+        type=Path,
+        default=Path("state/upstream-release-bot.json"),
+        help="Release bot advisory state path",
+    )
     args = parser.parse_args(argv)
 
     repo_root = Path.cwd()
@@ -566,6 +738,12 @@ def main(argv: list[str]) -> int:
         return 0
 
     github_token = __import__("os").environ.get("GITHUB_TOKEN")
+    bot_state = load_bot_state(args.state_path)
+    state_sources = bot_state.setdefault("sources", {})
+    if not isinstance(state_sources, dict):
+        state_sources = {}
+        bot_state["sources"] = state_sources
+    state_changed = False
     planned: list[PlannedUpdate] = []
     skipped_fetches = 0
     for config_path in config_paths:
@@ -585,7 +763,33 @@ def main(argv: list[str]) -> int:
                 repo = release_strategy.get("repo")
                 if not isinstance(repo, str):
                     raise RuntimeError(f"Missing source.release.repo in {config_path}")
-                releases = fetch_github_releases(repo, token=github_token)
+                state_key = github_release_state_key(repo)
+                state_entry = state_sources.get(state_key)
+                if not isinstance(state_entry, dict):
+                    state_entry = None
+                fetch_result = fetch_github_releases(
+                    repo, token=github_token, state_entry=state_entry
+                )
+                if fetch_result.not_modified:
+                    continue
+                releases = fetch_result.releases
+                version_strategy = normalized.get("version")
+                if not isinstance(version_strategy, dict):
+                    version_strategy = {"kind": "github_tag"}
+                next_entry = dict(state_entry or {})
+                if fetch_result.etag:
+                    next_entry["etag"] = fetch_result.etag
+                if fetch_result.last_modified:
+                    next_entry["last_modified"] = fetch_result.last_modified
+                next_entry["last_checked_at"] = utc_now_iso()
+                latest_version = latest_version_from_releases(
+                    releases, release_strategy, version_strategy
+                )
+                if latest_version is not None:
+                    next_entry["latest_version"] = latest_version
+                if next_entry != state_sources.get(state_key):
+                    state_sources[state_key] = next_entry
+                    state_changed = True
             else:
                 raise RuntimeError(f"Unsupported source.release.kind in {config_path}")
         except urllib.error.HTTPError as error:
@@ -677,6 +881,11 @@ def main(argv: list[str]) -> int:
         print(f"Generated {release_path}")
         created_releases += 1
         staged_paths.append(release_path)
+
+        if state_changed:
+            write_bot_state(args.state_path, bot_state)
+            if args.state_path not in staged_paths:
+                staged_paths.append(args.state_path)
 
         if args.create_prs:
             _open_or_update_pr(

--- a/tests/test_upstream_release_bot.py
+++ b/tests/test_upstream_release_bot.py
@@ -1,6 +1,7 @@
 import contextlib
 import importlib.util
 import io
+import json
 import os
 import subprocess
 import tempfile
@@ -40,6 +41,104 @@ def load_generator_module():
 class UpstreamReleaseBotTests(unittest.TestCase):
     def setUp(self) -> None:
         self.bot = load_module()
+
+    def test_load_bot_state_returns_empty_state_when_missing(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-state-") as tmp:
+            state = self.bot.load_bot_state(Path(tmp) / "state" / "upstream-release-bot.json")
+
+        self.assertEqual(state, {"schema_version": 1, "sources": {}})
+
+    def test_load_bot_state_warns_and_rebuilds_when_invalid(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-state-") as tmp:
+            state_path = Path(tmp) / "state" / "upstream-release-bot.json"
+            state_path.parent.mkdir(parents=True)
+            state_path.write_text("not json\n", encoding="utf-8")
+            stderr = io.StringIO()
+
+            with contextlib.redirect_stderr(stderr):
+                state = self.bot.load_bot_state(state_path)
+
+        self.assertEqual(state, {"schema_version": 1, "sources": {}})
+        self.assertIn("Ignoring invalid release bot state", stderr.getvalue())
+
+    def test_write_bot_state_sorts_keys_and_creates_parent(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-state-") as tmp:
+            state_path = Path(tmp) / "state" / "upstream-release-bot.json"
+
+            self.bot.write_bot_state(
+                state_path,
+                {
+                    "schema_version": 1,
+                    "sources": {
+                        "github_releases:z/z": {"etag": "z"},
+                        "github_releases:a/a": {"etag": "a"},
+                    },
+                },
+            )
+
+            self.assertEqual(
+                json.loads(state_path.read_text(encoding="utf-8")),
+                {
+                    "schema_version": 1,
+                    "sources": {
+                        "github_releases:a/a": {"etag": "a"},
+                        "github_releases:z/z": {"etag": "z"},
+                    },
+                },
+            )
+
+    def test_fetch_github_releases_sends_conditional_headers(self) -> None:
+        captured: dict[str, str | None] = {}
+
+        class FakeResponse:
+            headers = Message()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self) -> bytes:
+                return b"[]"
+
+        def fake_urlopen(request, timeout):
+            captured["if_none_match"] = request.headers.get("If-none-match")
+            captured["if_modified_since"] = request.headers.get("If-modified-since")
+            return FakeResponse()
+
+        with mock.patch.object(self.bot.urllib.request, "urlopen", side_effect=fake_urlopen):
+            result = self.bot.fetch_github_releases(
+                "aquasecurity/trivy",
+                token="token",
+                state_entry={"etag": "abc", "last_modified": "Mon, 27 Apr 2026 10:00:00 GMT"},
+            )
+
+        self.assertEqual(result.releases, [])
+        self.assertEqual(captured["if_none_match"], "abc")
+        self.assertEqual(captured["if_modified_since"], "Mon, 27 Apr 2026 10:00:00 GMT")
+
+    def test_fetch_github_releases_returns_not_modified_for_304(self) -> None:
+        headers = Message()
+
+        with mock.patch.object(
+            self.bot.urllib.request,
+            "urlopen",
+            side_effect=urllib.error.HTTPError(
+                "https://api.github.com/repos/aquasecurity/trivy/releases?per_page=20",
+                304,
+                "Not Modified",
+                headers,
+                None,
+            ),
+        ):
+            result = self.bot.fetch_github_releases(
+                "aquasecurity/trivy",
+                state_entry={"etag": "abc"},
+            )
+
+        self.assertTrue(result.not_modified)
+        self.assertEqual(result.releases, [])
 
     def _git(self, repo: Path, *args: str, env: dict[str, str] | None = None) -> str:
         completed = subprocess.run(
@@ -271,19 +370,21 @@ class UpstreamReleaseBotTests(unittest.TestCase):
                     mock.patch.object(
                         self.bot,
                         "fetch_github_releases",
-                        return_value=[
-                            {
-                                "tag_name": "v10.4.1",
-                                "draft": False,
-                                "prerelease": False,
-                                "assets": [
-                                    {
-                                        "name": "fd-v10.4.1-aarch64-apple-darwin.tar.gz",
-                                        "browser_download_url": "https://example.invalid/fd-aarch64.tar.gz",
-                                    }
-                                ],
-                            }
-                        ],
+                        return_value=self.bot.GithubReleaseFetchResult(
+                            releases=[
+                                {
+                                    "tag_name": "v10.4.1",
+                                    "draft": False,
+                                    "prerelease": False,
+                                    "assets": [
+                                        {
+                                            "name": "fd-v10.4.1-aarch64-apple-darwin.tar.gz",
+                                            "browser_download_url": "https://example.invalid/fd-aarch64.tar.gz",
+                                        }
+                                    ],
+                                }
+                            ]
+                        ),
                     ),
                     contextlib.redirect_stdout(stdout),
                     contextlib.redirect_stderr(stderr),
@@ -420,6 +521,365 @@ class UpstreamReleaseBotTests(unittest.TestCase):
             finally:
                 os.chdir(previous_cwd)
 
+    def test_main_skips_planning_when_github_release_not_modified(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-") as tmp:
+            tmp_path = Path(tmp)
+            packages_dir = tmp_path / "packages"
+            packages_dir.mkdir(parents=True)
+            (packages_dir / "trivy.toml").write_text(
+                textwrap.dedent(
+                    """
+                    name = "trivy"
+                    license = "Apache-2.0"
+                    homepage = "https://github.com/aquasecurity/trivy"
+
+                    [source.release]
+                    kind = "github_releases"
+                    repo = "aquasecurity/trivy"
+
+                    [source.checksum]
+                    kind = "asset_digest"
+
+                    [source.asset]
+                    kind = "release_asset_url"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            state_path = tmp_path / "state" / "upstream-release-bot.json"
+            self.bot.write_bot_state(
+                state_path,
+                {
+                    "schema_version": 1,
+                    "sources": {"github_releases:aquasecurity/trivy": {"etag": "abc"}},
+                },
+            )
+            stdout = io.StringIO()
+            generator = load_generator_module()
+            previous_cwd = Path.cwd()
+            os.chdir(tmp_path)
+            try:
+                with (
+                    mock.patch.object(self.bot, "_load_generator_module", return_value=generator),
+                    mock.patch.object(
+                        self.bot,
+                        "fetch_github_releases",
+                        return_value=self.bot.GithubReleaseFetchResult(
+                            releases=[], not_modified=True
+                        ),
+                    ) as fetch,
+                    contextlib.redirect_stdout(stdout),
+                ):
+                    result = self.bot.main(["--package", "trivy"])
+            finally:
+                os.chdir(previous_cwd)
+
+        self.assertEqual(result, 0)
+        fetch.assert_called_once()
+        self.assertIn("No new releases detected", stdout.getvalue())
+
+    def test_main_refreshes_state_after_successful_github_fetch_with_update(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-") as tmp:
+            tmp_path = Path(tmp)
+            packages_dir = tmp_path / "packages"
+            packages_dir.mkdir(parents=True)
+            (packages_dir / "ripgrep.toml").write_text(
+                textwrap.dedent(
+                    """
+                    name = "ripgrep"
+                    license = "MIT OR Unlicense"
+                    homepage = "https://github.com/BurntSushi/ripgrep"
+
+                    [source.release]
+                    kind = "github_releases"
+                    repo = "BurntSushi/ripgrep"
+
+                    [source.checksum]
+                    kind = "asset_digest"
+
+                    [source.asset]
+                    kind = "release_asset_url"
+
+                    [[artifacts]]
+                    target = "x86_64-unknown-linux-gnu"
+                    asset = "ripgrep-{version}-x86_64-unknown-linux-musl.tar.gz"
+                    archive = "tar.gz"
+                    strip_components = 1
+
+                    [[artifacts.binaries]]
+                    name = "rg"
+                    path = "rg"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            generator = load_generator_module()
+            previous_cwd = Path.cwd()
+            os.chdir(tmp_path)
+            try:
+                with (
+                    mock.patch.object(self.bot, "_load_generator_module", return_value=generator),
+                    mock.patch.object(self.bot, "utc_now_iso", return_value="2026-04-28T12:00:00Z"),
+                    mock.patch.object(
+                        self.bot,
+                        "fetch_github_releases",
+                        return_value=self.bot.GithubReleaseFetchResult(
+                            releases=[
+                                {
+                                    "tag_name": "15.2.0",
+                                    "draft": False,
+                                    "prerelease": False,
+                                    "assets": [
+                                        {
+                                            "name": "ripgrep-15.2.0-x86_64-unknown-linux-musl.tar.gz",
+                                            "browser_download_url": "https://example.invalid/ripgrep.tar.gz",
+                                            "digest": "sha256:88fd1ce767091fd8d4a99fdb2356e98c819f93f3b1f8663853a2dee9b438068a",
+                                        }
+                                    ],
+                                }
+                            ],
+                            etag="new-etag",
+                            last_modified="Tue, 28 Apr 2026 12:00:00 GMT",
+                        ),
+                    ),
+                ):
+                    result = self.bot.main(["--package", "ripgrep"])
+            finally:
+                os.chdir(previous_cwd)
+
+            state = json.loads(
+                (tmp_path / "state" / "upstream-release-bot.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+
+        self.assertEqual(result, 0)
+        self.assertEqual(
+            state["sources"]["github_releases:BurntSushi/ripgrep"],
+            {
+                "etag": "new-etag",
+                "last_modified": "Tue, 28 Apr 2026 12:00:00 GMT",
+                "last_checked_at": "2026-04-28T12:00:00Z",
+                "latest_version": "15.2.0",
+            },
+        )
+
+    def test_dry_run_does_not_write_release_bot_state(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-") as tmp:
+            tmp_path = Path(tmp)
+            packages_dir = tmp_path / "packages"
+            packages_dir.mkdir(parents=True)
+            (packages_dir / "trivy.toml").write_text(
+                textwrap.dedent(
+                    """
+                    name = "trivy"
+                    license = "Apache-2.0"
+                    homepage = "https://github.com/aquasecurity/trivy"
+
+                    [source.release]
+                    kind = "github_releases"
+                    repo = "aquasecurity/trivy"
+
+                    [source.checksum]
+                    kind = "asset_digest"
+
+                    [source.asset]
+                    kind = "release_asset_url"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            generator = load_generator_module()
+            previous_cwd = Path.cwd()
+            os.chdir(tmp_path)
+            try:
+                with (
+                    mock.patch.object(self.bot, "_load_generator_module", return_value=generator),
+                    mock.patch.object(
+                        self.bot,
+                        "fetch_github_releases",
+                        return_value=self.bot.GithubReleaseFetchResult(releases=[]),
+                    ),
+                ):
+                    result = self.bot.main(["--dry-run", "--package", "trivy"])
+            finally:
+                os.chdir(previous_cwd)
+
+        self.assertEqual(result, 0)
+        self.assertFalse((tmp_path / "state" / "upstream-release-bot.json").exists())
+
+    def test_validate_generated_paths_runs_focused_registry_checks(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-validate-") as tmp:
+            repo = Path(tmp)
+            calls: list[list[str]] = []
+
+            def fake_run(cmd, *, cwd):
+                calls.append(cmd)
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+            with mock.patch.object(self.bot, "_run", side_effect=fake_run):
+                self.bot.validate_generated_paths(
+                    repo_root=repo,
+                    staged_paths=[
+                        Path("packages/ripgrep.toml"),
+                        Path("releases/ripgrep/15.2.0.toml"),
+                        Path("state/upstream-release-bot.json"),
+                    ],
+                )
+
+        self.assertIn(
+            ["python3", "scripts/registry-validate-source.py", "packages/ripgrep.toml"],
+            calls,
+        )
+        self.assertIn(
+            [
+                "python3",
+                "scripts/registry-validate.py",
+                "--allow-missing-signatures",
+                "packages/ripgrep.toml",
+                "releases/ripgrep/15.2.0.toml",
+            ],
+            calls,
+        )
+
+    def test_validate_generated_paths_rejects_unexpected_paths(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-validate-") as tmp:
+            with self.assertRaisesRegex(RuntimeError, "unexpected generated path"):
+                self.bot.validate_generated_paths(
+                    repo_root=Path(tmp),
+                    staged_paths=[Path("scripts/upstream-release-bot.py")],
+                )
+
+    def test_open_or_update_pr_enables_automerge_for_new_pr(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-pr-") as tmp:
+            repo = Path(tmp)
+            calls: list[list[str]] = []
+
+            def fake_run(cmd, *, cwd):
+                calls.append(cmd)
+                if cmd[:3] == ["git", "ls-remote", "--heads"]:
+                    return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+                if cmd == ["git", "diff", "--cached", "--name-only"]:
+                    return subprocess.CompletedProcess(
+                        cmd,
+                        0,
+                        stdout="packages/ripgrep.toml\nreleases/ripgrep/15.2.0.toml\n",
+                        stderr="",
+                    )
+                if cmd[:5] == ["gh", "pr", "list", "--head", "upstream-release/ripgrep/15.2.0"]:
+                    return subprocess.CompletedProcess(cmd, 0, stdout="[]", stderr="")
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+            with (
+                mock.patch.object(self.bot, "_run", side_effect=fake_run),
+                mock.patch.object(self.bot, "validate_generated_paths"),
+            ):
+                self.bot._open_or_update_pr(
+                    repo_root=repo,
+                    staged_paths=[
+                        Path("packages/ripgrep.toml"),
+                        Path("releases/ripgrep/15.2.0.toml"),
+                    ],
+                    package="ripgrep",
+                    version="15.2.0",
+                    base_branch="main",
+                    branch_prefix="upstream-release",
+                )
+
+        self.assertIn(
+            ["gh", "pr", "merge", "upstream-release/ripgrep/15.2.0", "--auto", "--squash"],
+            calls,
+        )
+
+    def test_open_or_update_pr_enables_automerge_for_existing_pr(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-pr-") as tmp:
+            repo = Path(tmp)
+            calls: list[list[str]] = []
+
+            def fake_run(cmd, *, cwd):
+                calls.append(cmd)
+                if cmd[:3] == ["git", "ls-remote", "--heads"]:
+                    return subprocess.CompletedProcess(
+                        cmd,
+                        0,
+                        stdout="abc\trefs/heads/upstream-release/ripgrep/15.2.0\n",
+                        stderr="",
+                    )
+                if cmd == ["git", "diff", "--cached", "--name-only"]:
+                    return subprocess.CompletedProcess(
+                        cmd,
+                        0,
+                        stdout="packages/ripgrep.toml\nreleases/ripgrep/15.2.0.toml\n",
+                        stderr="",
+                    )
+                if cmd[:5] == ["gh", "pr", "list", "--head", "upstream-release/ripgrep/15.2.0"]:
+                    return subprocess.CompletedProcess(cmd, 0, stdout='[{"number": 12}]', stderr="")
+                if cmd[:3] == ["git", "cat-file", "-e"]:
+                    return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+            with (
+                mock.patch.object(self.bot, "_run", side_effect=fake_run),
+                mock.patch.object(self.bot, "validate_generated_paths"),
+                mock.patch.object(self.bot, "_stash_paths_for_branch_switch", return_value=None),
+            ):
+                self.bot._open_or_update_pr(
+                    repo_root=repo,
+                    staged_paths=[
+                        Path("packages/ripgrep.toml"),
+                        Path("releases/ripgrep/15.2.0.toml"),
+                    ],
+                    package="ripgrep",
+                    version="15.2.0",
+                    base_branch="main",
+                    branch_prefix="upstream-release",
+                )
+
+        self.assertIn(["gh", "pr", "merge", "12", "--auto", "--squash"], calls)
+
+    def test_open_or_update_pr_enables_automerge_when_existing_branch_has_no_diff(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-pr-") as tmp:
+            repo = Path(tmp)
+            calls: list[list[str]] = []
+
+            def fake_run(cmd, *, cwd):
+                calls.append(cmd)
+                if cmd[:3] == ["git", "ls-remote", "--heads"]:
+                    return subprocess.CompletedProcess(
+                        cmd,
+                        0,
+                        stdout="abc\trefs/heads/upstream-release/ripgrep/15.2.0\n",
+                        stderr="",
+                    )
+                if cmd == ["git", "diff", "--cached", "--name-only"]:
+                    return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+                if cmd[:5] == ["gh", "pr", "list", "--head", "upstream-release/ripgrep/15.2.0"]:
+                    return subprocess.CompletedProcess(cmd, 0, stdout='[{"number": 12}]', stderr="")
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+            with (
+                mock.patch.object(self.bot, "_run", side_effect=fake_run),
+                mock.patch.object(self.bot, "validate_generated_paths"),
+                mock.patch.object(self.bot, "_stash_paths_for_branch_switch", return_value=None),
+            ):
+                self.bot._open_or_update_pr(
+                    repo_root=repo,
+                    staged_paths=[
+                        Path("packages/ripgrep.toml"),
+                        Path("releases/ripgrep/15.2.0.toml"),
+                    ],
+                    package="ripgrep",
+                    version="15.2.0",
+                    base_branch="main",
+                    branch_prefix="upstream-release",
+                )
+
+        self.assertIn(["gh", "pr", "merge", "12", "--auto", "--squash"], calls)
+        self.assertNotIn(["git", "commit", "-m", "chore(registry): add ripgrep 15.2.0"], calls)
+
     def test_open_or_update_pr_handles_generated_file_that_conflicts_with_remote_branch(self) -> None:
         with tempfile.TemporaryDirectory(prefix="release-bot-git-") as tmp:
             tmp_path = Path(tmp)
@@ -463,6 +923,8 @@ class UpstreamReleaseBotTests(unittest.TestCase):
                         print("[]")
                     elif sys.argv[1:3] == ["pr", "create"]:
                         print("created")
+                    elif sys.argv[1:3] == ["pr", "merge"]:
+                        print("automerge enabled")
                     else:
                         raise SystemExit(f"unexpected gh args: {sys.argv[1:]}")
                     """
@@ -477,14 +939,15 @@ class UpstreamReleaseBotTests(unittest.TestCase):
             previous_path = os.environ.get("PATH", "")
             os.environ["PATH"] = env["PATH"]
             try:
-                self.bot._open_or_update_pr(
-                    repo_root=repo,
-                    staged_paths=[release_path.relative_to(repo)],
-                    package="beekeeper-studio",
-                    version="5.6.0",
-                    base_branch="main",
-                    branch_prefix="upstream-release",
-                )
+                with mock.patch.object(self.bot, "validate_generated_paths"):
+                    self.bot._open_or_update_pr(
+                        repo_root=repo,
+                        staged_paths=[release_path.relative_to(repo)],
+                        package="beekeeper-studio",
+                        version="5.6.0",
+                        base_branch="main",
+                        branch_prefix="upstream-release",
+                    )
             finally:
                 os.environ["PATH"] = previous_path
 
@@ -611,20 +1074,22 @@ class UpstreamReleaseBotTests(unittest.TestCase):
                     mock.patch.object(
                         self.bot,
                         "fetch_github_releases",
-                        return_value=[
-                            {
-                                "tag_name": "15.2.0",
-                                "draft": False,
-                                "prerelease": False,
-                                "assets": [
-                                    {
-                                        "name": "ripgrep-15.2.0-x86_64-unknown-linux-musl.tar.gz",
-                                        "browser_download_url": "https://example.invalid/ripgrep.tar.gz",
-                                        "digest": "sha256:88fd1ce767091fd8d4a99fdb2356e98c819f93f3b1f8663853a2dee9b438068a",
-                                    }
-                                ],
-                            }
-                        ],
+                        return_value=self.bot.GithubReleaseFetchResult(
+                            releases=[
+                                {
+                                    "tag_name": "15.2.0",
+                                    "draft": False,
+                                    "prerelease": False,
+                                    "assets": [
+                                        {
+                                            "name": "ripgrep-15.2.0-x86_64-unknown-linux-musl.tar.gz",
+                                            "browser_download_url": "https://example.invalid/ripgrep.tar.gz",
+                                            "digest": "sha256:88fd1ce767091fd8d4a99fdb2356e98c819f93f3b1f8663853a2dee9b438068a",
+                                        }
+                                    ],
+                                }
+                            ]
+                        ),
                     ),
                     contextlib.redirect_stdout(stdout),
                 ):

--- a/tests/test_upstream_release_bot.py
+++ b/tests/test_upstream_release_bot.py
@@ -5,6 +5,8 @@ import os
 import subprocess
 import tempfile
 import textwrap
+import urllib.error
+from email.message import Message
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -295,6 +297,128 @@ class UpstreamReleaseBotTests(unittest.TestCase):
             self.assertIn("Skipping fd 10.4.1: incomplete upstream release", stderr.getvalue())
             self.assertIn("skipped 1 incomplete update(s)", stdout.getvalue())
             self.assertIn("wrote 0 release manifest(s)", stdout.getvalue())
+
+    def test_skips_release_fetch_http_error_instead_of_failing(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-") as tmp:
+            tmp_path = Path(tmp)
+            packages_dir = tmp_path / "packages"
+            packages_dir.mkdir(parents=True)
+            (packages_dir / "trivy.toml").write_text(
+                textwrap.dedent(
+                    """
+                    name = "trivy"
+                    license = "Apache-2.0"
+                    homepage = "https://github.com/aquasecurity/trivy"
+
+                    [source.release]
+                    kind = "github_releases"
+                    repo = "aquasecurity/trivy"
+
+                    [source.checksum]
+                    kind = "asset_digest"
+
+                    [source.asset]
+                    kind = "release_asset_url"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            generator = load_generator_module()
+            headers = Message()
+            headers["x-ratelimit-remaining"] = "0"
+            previous_cwd = Path.cwd()
+            os.chdir(tmp_path)
+            try:
+                with (
+                    mock.patch.object(
+                        self.bot,
+                        "_load_generator_module",
+                        return_value=generator,
+                    ),
+                    mock.patch.object(
+                        self.bot,
+                        "fetch_github_releases",
+                        side_effect=urllib.error.HTTPError(
+                            "https://api.github.com/repos/aquasecurity/trivy/releases?per_page=20",
+                            403,
+                            "Forbidden",
+                            headers,
+                            None,
+                        ),
+                    ),
+                    contextlib.redirect_stdout(stdout),
+                    contextlib.redirect_stderr(stderr),
+                ):
+                    result = self.bot.main(["--package", "trivy"])
+            finally:
+                os.chdir(previous_cwd)
+
+            self.assertEqual(result, 0)
+            self.assertFalse((tmp_path / "releases" / "trivy").exists())
+            self.assertIn(
+                "Skipping trivy: failed to fetch upstream releases (HTTP 403 Forbidden)",
+                stderr.getvalue(),
+            )
+            self.assertIn("skipped 1 release fetch(es)", stdout.getvalue())
+            self.assertIn("No new releases detected", stdout.getvalue())
+
+    def test_release_fetch_non_rate_http_error_still_fails(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-") as tmp:
+            tmp_path = Path(tmp)
+            packages_dir = tmp_path / "packages"
+            packages_dir.mkdir(parents=True)
+            (packages_dir / "badrepo.toml").write_text(
+                textwrap.dedent(
+                    """
+                    name = "badrepo"
+                    license = "MIT"
+                    homepage = "https://github.com/example/missing"
+
+                    [source.release]
+                    kind = "github_releases"
+                    repo = "example/missing"
+
+                    [source.checksum]
+                    kind = "asset_digest"
+
+                    [source.asset]
+                    kind = "release_asset_url"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            generator = load_generator_module()
+            previous_cwd = Path.cwd()
+            os.chdir(tmp_path)
+            try:
+                with (
+                    mock.patch.object(
+                        self.bot,
+                        "_load_generator_module",
+                        return_value=generator,
+                    ),
+                    mock.patch.object(
+                        self.bot,
+                        "fetch_github_releases",
+                        side_effect=urllib.error.HTTPError(
+                            "https://api.github.com/repos/example/missing/releases?per_page=20",
+                            404,
+                            "Not Found",
+                            Message(),
+                            None,
+                        ),
+                    ),
+                ):
+                    with self.assertRaises(urllib.error.HTTPError):
+                        self.bot.main(["--package", "badrepo"])
+            finally:
+                os.chdir(previous_cwd)
 
     def test_open_or_update_pr_handles_generated_file_that_conflicts_with_remote_branch(self) -> None:
         with tempfile.TemporaryDirectory(prefix="release-bot-git-") as tmp:


### PR DESCRIPTION
## Summary
- add advisory release-bot state for GitHub release validators and 304 handling
- include state with generated release PRs while avoiding state-only PR churn
- validate generated paths before enabling PR automerge
- enable automerge for bot PRs after required checks pass

## Verification
- python3 -m unittest tests.test_upstream_release_bot -v
- python3 -m unittest discover -s tests -v
- python3 scripts/registry-validate-source.py packages/*.toml
- python3 scripts/upstream-release-bot.py --dry-run --package trivy