### PR TITLE
fix(registry): retry transient smoke downloads

### DIFF
--- a/scripts/registry-smoke-install.py
+++ b/scripts/registry-smoke-install.py
@@ -9,7 +9,9 @@ import shutil
 import sys
 import tarfile
 import tempfile
+import time
 import tomllib
+import urllib.error
 import urllib.request
 import zipfile
 from pathlib import Path, PurePosixPath
@@ -91,13 +93,36 @@ def choose_artifact(
     return artifacts[0]
 
 
+DOWNLOAD_ATTEMPTS = 3
+TRANSIENT_HTTP_STATUS_CODES = {408, 429, 500, 502, 503, 504}
+
+
+def is_transient_download_error(error: BaseException) -> bool:
+    if isinstance(error, urllib.error.HTTPError):
+        return error.code in TRANSIENT_HTTP_STATUS_CODES
+    return isinstance(error, urllib.error.URLError)
+
+
 def download(url: str, dest: Path) -> None:
-    req = urllib.request.Request(
-        url, headers={"User-Agent": "crosspack-registry-ci/1.0"}
-    )
-    with urllib.request.urlopen(req, timeout=60) as resp:
-        with dest.open("wb") as out:
-            shutil.copyfileobj(resp, out)
+    last_error: BaseException | None = None
+    for attempt in range(DOWNLOAD_ATTEMPTS):
+        req = urllib.request.Request(
+            url, headers={"User-Agent": "crosspack-registry-ci/1.0"}
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                with dest.open("wb") as out:
+                    shutil.copyfileobj(resp, out)
+            return
+        except (urllib.error.HTTPError, urllib.error.URLError) as error:
+            if not is_transient_download_error(error) or attempt == DOWNLOAD_ATTEMPTS - 1:
+                raise
+            last_error = error
+            time.sleep(2**attempt)
+
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError(f"failed to download {url}")
 
 
 def sha256_file(path: Path) -> str:

--- a/tests/test_registry_smoke_install.py
+++ b/tests/test_registry_smoke_install.py
@@ -1,10 +1,12 @@
 import hashlib
 import importlib.util
 import io
+import urllib.error
 import tempfile
 import textwrap
 import unittest
 import zipfile
+from email.message import Message
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest import mock
@@ -151,6 +153,70 @@ class RegistrySmokeInstallTests(unittest.TestCase):
         self.assertTrue(ok)
         self.assertIn("demo@1.0.0", message)
         self.assertIn("target=fallback-target", message)
+
+    def test_download_retries_transient_http_error(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="smoke-test-") as tmp:
+            dest = Path(tmp) / "payload"
+            attempts = 0
+
+            class FakeResponse:
+                def __init__(self) -> None:
+                    self._sent = False
+
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, exc_type, exc, tb):
+                    return False
+
+                def read(self, _size: int = -1) -> bytes:
+                    if self._sent:
+                        return b""
+                    self._sent = True
+                    return b"demo-payload"
+
+            def fake_urlopen(_request, timeout):
+                nonlocal attempts
+                attempts += 1
+                if attempts == 1:
+                    raise urllib.error.HTTPError(
+                        "https://example.invalid/demo.tar.gz",
+                        502,
+                        "Bad Gateway",
+                        Message(),
+                        None,
+                    )
+                return FakeResponse()
+
+            with (
+                mock.patch.object(self.smoke.urllib.request, "urlopen", side_effect=fake_urlopen),
+                mock.patch.object(self.smoke.time, "sleep"),
+            ):
+                self.smoke.download("https://example.invalid/demo.tar.gz", dest)
+            payload = dest.read_bytes()
+
+        self.assertEqual(attempts, 2)
+        self.assertEqual(payload, b"demo-payload")
+
+    def test_download_fails_fast_for_non_transient_http_error(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="smoke-test-") as tmp:
+            dest = Path(tmp) / "payload"
+
+            with mock.patch.object(
+                self.smoke.urllib.request,
+                "urlopen",
+                side_effect=urllib.error.HTTPError(
+                    "https://example.invalid/demo.tar.gz",
+                    404,
+                    "Not Found",
+                    Message(),
+                    None,
+                ),
+            ) as urlopen:
+                with self.assertRaises(urllib.error.HTTPError):
+                    self.smoke.download("https://example.invalid/demo.tar.gz", dest)
+
+        self.assertEqual(urlopen.call_count, 1)
 
     def test_app_bundle_canary_succeeds(self) -> None:
         ok, message = self.smoke.app_bundle_canary()


### PR DESCRIPTION
## Summary
- retry smoke-install artifact downloads on transient HTTP/URL failures
- keep non-transient HTTP errors, such as 404, failing immediately
- cover the 502 retry path that caused the transient main quality gate failure

## Root cause
The failed main quality run hit an upstream/proxy `HTTP Error 502: Bad Gateway or Proxy Error` while downloading `kind@0.31.0` during the full smoke-install scan. A later quality gate run on the same SHA passed, which confirms the manifest was valid and the failure was transient.

## Verification
- python3 -m unittest tests.test_registry_smoke_install.RegistrySmokeInstallTests.test_download_retries_transient_http_error tests.test_registry_smoke_install.RegistrySmokeInstallTests.test_download_fails_fast_for_non_transient_http_error -v
- python3 -m unittest discover -s tests -v
- python3 scripts/registry-validate-source.py packages/*.toml