### PR TITLE
fix(registry): scope quality gate to changed manifests

### DIFF
--- a/.github/workflows/registry-quality-gate.yml
+++ b/.github/workflows/registry-quality-gate.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Collect changed manifests
         id: changed
@@ -57,10 +58,12 @@ jobs:
             RELEASE_MANIFESTS_JSON="$release_manifests_json" python3 -c 'import json, os; print(len(json.loads(os.environ["RELEASE_MANIFESTS_JSON"])))'
           )"
 
-          echo "manifests_json=$manifests_json" >> "$GITHUB_OUTPUT"
-          echo "manifest_count=$manifest_count" >> "$GITHUB_OUTPUT"
-          echo "release_manifests_json=$release_manifests_json" >> "$GITHUB_OUTPUT"
-          echo "release_manifest_count=$release_manifest_count" >> "$GITHUB_OUTPUT"
+          {
+            echo "manifests_json=$manifests_json"
+            echo "manifest_count=$manifest_count"
+            echo "release_manifests_json=$release_manifests_json"
+            echo "release_manifest_count=$release_manifest_count"
+          } >> "$GITHUB_OUTPUT"
 
   preflight:
     name: Validate Registry Manifests
@@ -71,6 +74,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Registry preflight (PR changed manifests)
         if: github.event_name == 'pull_request'
@@ -80,8 +84,14 @@ jobs:
           REGISTRY_PREFLIGHT_SKIP_SMOKE: '1'
         run: ./scripts/registry-preflight.sh
 
+      - name: Registry preflight (workflow-run changed manifests)
+        if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
+        env:
+          REGISTRY_BASE_SHA: ${{ github.event.workflow_run.head_sha }}^
+        run: ./scripts/registry-preflight.sh
+
       - name: Registry preflight (full scan)
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'workflow_dispatch'
         env:
           REGISTRY_PREFLIGHT_ALL: '1'
         run: ./scripts/registry-preflight.sh

--- a/scripts/registry-preflight.sh
+++ b/scripts/registry-preflight.sh
@@ -16,8 +16,8 @@ load_manifests() {
 load_manifests "$repo_root/scripts/registry-changed-manifests.sh"
 
 if [[ "${#manifests[@]}" -eq 0 ]]; then
-  echo "No manifest changes detected. Running full registry preflight to validate tooling changes."
-  load_manifests env REGISTRY_PREFLIGHT_ALL=1 "$repo_root/scripts/registry-changed-manifests.sh"
+  echo "No manifest changes detected. Skipping registry preflight."
+  exit 0
 fi
 
 echo "Running registry preflight on ${#manifests[@]} manifest(s)..."

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -17,6 +17,33 @@ class GitHubWorkflowTests(unittest.TestCase):
         self.assertIn("      - completed", quality_gate)
         self.assertIn("      - main", quality_gate)
 
+    def test_registry_quality_gate_workflow_run_uses_changed_manifests(self) -> None:
+        quality_gate = (
+            REPO_ROOT / ".github" / "workflows" / "registry-quality-gate.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("Registry preflight (workflow-run changed manifests)", quality_gate)
+        self.assertIn("REGISTRY_BASE_SHA: ${{ github.event.workflow_run.head_sha }}^", quality_gate)
+        self.assertIn("ref: ${{ github.event.workflow_run.head_sha || github.sha }}", quality_gate)
+        self.assertGreaterEqual(
+            quality_gate.count("ref: ${{ github.event.workflow_run.head_sha || github.sha }}"),
+            2,
+        )
+        self.assertIn("if: github.event_name == 'workflow_dispatch'", quality_gate)
+
+        workflow_run_step = quality_gate.split(
+            "Registry preflight (workflow-run changed manifests)", 1
+        )[1].split("Registry preflight (full scan)", 1)[0]
+        self.assertNotIn("REGISTRY_PREFLIGHT_ALL", workflow_run_step)
+
+    def test_registry_preflight_does_not_fallback_to_full_scan(self) -> None:
+        preflight = (REPO_ROOT / "scripts" / "registry-preflight.sh").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertNotIn("No manifest changes detected. Running full registry preflight", preflight)
+        self.assertIn("No manifest changes detected. Skipping registry preflight.", preflight)
+
     def test_upstream_release_bot_uses_package_templates_directly(self) -> None:
         workflow = (REPO_ROOT / ".github" / "workflows" / "upstream-release-bot.yml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary
- stop falling back to full registry preflight when no manifest diff exists
- make post-sign main quality checks validate/smoke only manifests changed by the signing workflow commit
- keep full registry scans explicit via workflow_dispatch
- add workflow regression tests for proportional quality-gate behavior

## Verification
- python3 -m unittest tests.test_github_workflows -v
- actionlint .github/workflows/registry-quality-gate.yml
- python3 -m unittest discover -s tests -v
- python3 scripts/registry-validate-source.py packages/*.toml
- ./scripts/registry-preflight.sh