### PR TITLE
fix(release-bot): preserve generated files across PR branches

### DIFF
--- a/scripts/upstream-release-bot.py
+++ b/scripts/upstream-release-bot.py
@@ -511,6 +511,22 @@ def _run(cmd: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(cmd, cwd=cwd, check=True, text=True, capture_output=True)
 
 
+def _snapshot_paths(repo_root: Path, paths: list[Path]) -> dict[Path, bytes]:
+    snapshot: dict[Path, bytes] = {}
+    for path in paths:
+        full_path = repo_root / path
+        if full_path.exists():
+            snapshot[path] = full_path.read_bytes()
+    return snapshot
+
+
+def _restore_path_snapshot(repo_root: Path, snapshot: dict[Path, bytes]) -> None:
+    for path, content in snapshot.items():
+        full_path = repo_root / path
+        full_path.parent.mkdir(parents=True, exist_ok=True)
+        full_path.write_bytes(content)
+
+
 def validate_generated_paths(*, repo_root: Path, staged_paths: list[Path]) -> None:
     package_paths: list[str] = []
     release_paths: list[str] = []
@@ -626,6 +642,7 @@ def _open_or_update_pr(
         f"- add generated package/release metadata for `{package}` `{version}`\n"
         "- produced by upstream release bot\n"
     )
+    path_snapshot = _snapshot_paths(repo_root, staged_paths)
 
     _run(["git", "checkout", base_branch], cwd=repo_root)
     remote_branch = _run(
@@ -651,6 +668,7 @@ def _open_or_update_pr(
             )
     else:
         _run(["git", "switch", "-C", branch_name, base_branch], cwd=repo_root)
+    _restore_path_snapshot(repo_root, path_snapshot)
     if staged_paths:
         _run(["git", "add", *(str(path) for path in staged_paths)], cwd=repo_root)
     validate_generated_paths(repo_root=repo_root, staged_paths=staged_paths)

--- a/tests/test_upstream_release_bot.py
+++ b/tests/test_upstream_release_bot.py
@@ -961,6 +961,90 @@ class UpstreamReleaseBotTests(unittest.TestCase):
                 self._git(repo, "log", "-1", "--pretty=%s"),
             )
 
+    def test_open_or_update_pr_restores_generated_state_removed_by_branch_switch(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-git-") as tmp:
+            tmp_path = Path(tmp)
+            remote = tmp_path / "remote.git"
+            repo = tmp_path / "repo"
+            subprocess.run(["git", "init", "--bare", remote], check=True)
+            subprocess.run(["git", "init", "-b", "main", repo], check=True)
+
+            self._git(repo, "config", "user.name", "Test User")
+            self._git(repo, "config", "user.email", "test@example.com")
+            self._git(repo, "remote", "add", "origin", str(remote))
+
+            packages_dir = repo / "packages"
+            packages_dir.mkdir()
+            package_path = packages_dir / "gh.toml"
+            package_path.write_text('name = "gh"\n', encoding="utf-8")
+            self._git(repo, "add", "packages/gh.toml")
+            self._git(repo, "commit", "-m", "base")
+            self._git(repo, "push", "-u", "origin", "main")
+
+            self._git(repo, "switch", "-c", "upstream-release/deno/2.7.14")
+            state_path = repo / "state" / "upstream-release-bot.json"
+            state_path.parent.mkdir()
+            state_path.write_text('{"schema_version":1}\n', encoding="utf-8")
+            self._git(repo, "add", "state/upstream-release-bot.json")
+            self._git(repo, "commit", "-m", "existing release branch")
+
+            release_path = repo / "releases" / "gh" / "2.92.0.toml"
+            release_path.parent.mkdir(parents=True)
+            release_path.write_text('version = "2.92.0"\n', encoding="utf-8")
+
+            fake_bin = tmp_path / "bin"
+            fake_bin.mkdir()
+            gh = fake_bin / "gh"
+            gh.write_text(
+                textwrap.dedent(
+                    """
+                    #!/usr/bin/env python3
+                    import sys
+
+                    if sys.argv[1:4] == ["pr", "list", "--head"]:
+                        print("[]")
+                    elif sys.argv[1:3] == ["pr", "create"]:
+                        print("created")
+                    elif sys.argv[1:3] == ["pr", "merge"]:
+                        print("automerge enabled")
+                    else:
+                        raise SystemExit(f"unexpected gh args: {sys.argv[1:]}")
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            gh.chmod(0o755)
+
+            previous_path = os.environ.get("PATH", "")
+            os.environ["PATH"] = f"{fake_bin}:{previous_path}"
+            try:
+                with mock.patch.object(self.bot, "validate_generated_paths"):
+                    self.bot._open_or_update_pr(
+                        repo_root=repo,
+                        staged_paths=[
+                            package_path.relative_to(repo),
+                            release_path.relative_to(repo),
+                            state_path.relative_to(repo),
+                        ],
+                        package="gh",
+                        version="2.92.0",
+                        base_branch="main",
+                        branch_prefix="upstream-release",
+                    )
+            finally:
+                os.environ["PATH"] = previous_path
+
+            self.assertEqual(
+                self._git(repo, "branch", "--show-current"),
+                "upstream-release/gh/2.92.0",
+            )
+            self.assertTrue(state_path.exists())
+            self.assertIn(
+                "chore(registry): add gh 2.92.0",
+                self._git(repo, "log", "-1", "--pretty=%s"),
+            )
+
     def test_plan_updates_for_nodejs_dist_major_channel(self) -> None:
         with tempfile.TemporaryDirectory(prefix="release-bot-") as tmp:
             tmp_path = Path(tmp)


### PR DESCRIPTION
## Summary
- snapshot generated release-bot files before switching branches for PR creation
- restore those files on the target PR branch so state files that are absent on main can still be staged
- add regression coverage for the state file being removed by a branch switch

## Tests
- python3 -m unittest tests.test_upstream_release_bot
- python3 -m unittest discover tests