### PR TITLE
feat(registry): add dotfiles package manifests

### DIFF
--- a/.brv/.gitignore
+++ b/.brv/.gitignore
@@ -19,6 +19,8 @@ _index.md
 *.overview.md
 # END opencode-byterover
 
+
+
 # Review backups
 
 # Generated files

--- a/.brv/context-tree/ci/github_actions/dotfiles_package_batch_for_registry.md
+++ b/.brv/context-tree/ci/github_actions/dotfiles_package_batch_for_registry.md
@@ -1,0 +1,70 @@
+---
+title: Dotfiles Package Batch for Registry
+summary: Added 11 dotfiles-derived package manifests to the registry, with validation passing and signature sidecars deferred to the merge signing workflow.
+tags: []
+related: [ci/github_actions/registry_quality_gate_and_signing_workflow_fix.md, ci/github_actions/dotfiles_package_batch_for_registry.abstract.md, ci/github_actions/dotfiles_package_batch_for_registry.overview.md]
+keywords: []
+createdAt: '2026-05-03T01:37:34.841Z'
+updatedAt: '2026-05-03T01:37:34.841Z'
+---
+## Reason
+Record the batch of packages added from chezmoi-dotfiles and the validation outcomes.
+
+## Raw Concept
+**Task:**
+Add the next batch of high-value packages from the user's dotfiles repository into the registry.
+
+**Changes:**
+- Added package manifests for ast-grep, chezmoi, fastfetch, jj, lsd, mise, neovim, opencode, stylua, yazi, and yt-dlp
+- Validated registry source configs and manifests
+- Ran release-bot dry-runs for the new packages
+- Deferred signature sidecars to the merge signing workflow
+
+**Files:**
+- packages/ast-grep.toml
+- packages/chezmoi.toml
+- packages/fastfetch.toml
+- packages/jj.toml
+- packages/lsd.toml
+- packages/mise.toml
+- packages/neovim.toml
+- packages/opencode.toml
+- packages/stylua.toml
+- packages/yazi.toml
+- packages/yt-dlp.toml
+- .github/workflows/registry-quality-gate.yml
+- .github/workflows/sign-manifests-on-merge.yml
+
+**Flow:**
+identify dotfiles package set -> add package manifests -> validate source configs and manifests -> run release dry-runs -> defer signature sidecars until merge signing
+
+**Timestamp:** 2026-05-02
+
+**Author:** Ian
+
+**Patterns:**
+- `REGISTRY_PREFLIGHT_ALL=1 REGISTRY_PREFLIGHT_SKIP_SMOKE=1 ./scripts/registry-preflight.sh` - Preflight command that fails until signature sidecars exist
+
+## Narrative
+### Structure
+A single registry batch captured the dotfiles-derived package additions and the validation pipeline results for the worktree branch.
+
+### Dependencies
+The validation flow depends on allowing missing signatures during PR checks, with signature sidecars created by the merge signing workflow after merge.
+
+### Highlights
+The package batch was intentionally limited to manifests only; GUI casks and system/runtime libraries were excluded as less suitable for the registry batch.
+
+### Rules
+PR validation can use --allow-missing-signatures; the signing workflow creates sidecars after merge.
+
+### Examples
+The added package set included developer CLI tools such as chezmoi, fastfetch, jj, neovim, yazi, and yt-dlp.
+
+## Facts
+- **source_repo**: The registry batch came from the dotfiles repository ian-pascoe/chezmoi-dotfiles. [project]
+- **worktree_branch**: The work was done in the opencode/kimaki-package-batch-1 branch inside the /home/ianpascoe/.kimaki/worktrees/1010908a/package-batch-1 worktree. [project]
+- **packages_added**: 11 package manifests were added: ast-grep, chezmoi, fastfetch, jj, lsd, mise, neovim, opencode, stylua, yazi, and yt-dlp. [project]
+- **validation_results**: Registry validation passed with 79 source configs and 224 manifests when allowing missing signatures. [project]
+- **release_dry_run**: Release bot dry-runs passed for all 11 new packages. [project]
+- **signature_sidecars**: The preflight script failed because the new package manifests did not yet have .toml.sig sidecars. [project]

--- a/.brv/context-tree/ci/github_actions/registry_package_formats_and_gui_cask_support.md
+++ b/.brv/context-tree/ci/github_actions/registry_package_formats_and_gui_cask_support.md
@@ -1,0 +1,78 @@
+---
+title: Registry Package Formats and GUI Cask Support
+summary: The registry already supports DMG packages, uses neovide as the schema reference for GUI casks, and a second batch added 12 manifests including GUI apps plus validation and dry-runs that all passed.
+tags: []
+related:
+  - ci/github_actions/dotfiles_package_batch_for_registry.md
+  - ci/github_actions/registry_quality_gate_and_signing_workflow_fix.md
+keywords: []
+createdAt: '2026-05-03T01:55:35.414Z'
+updatedAt: '2026-05-03T01:55:35.414Z'
+consolidated_at: '2026-05-03T02:26:35.104Z'
+consolidated_from:
+  - {date: '2026-05-03T02:26:35.104Z', path: ci/github_actions/registry_package_formats.md, reason: 'These files cover the same registry package-format topic and the more detailed GUI-cask batch note supersedes the shorter dmg-support note. The richer file should absorb the shared dmg/neovide facts and keep the batch validation details, package lists, and checksum edge case.'}
+---
+## Reason
+Document registry package format support and the GUI cask batch update using neovide as the DMG reference
+
+## Raw Concept
+**Task:**
+Document the registry batch update that extended support to GUI casks and verified package manifests
+
+**Changes:**
+- Confirmed DMG support in the registry
+- Used neovide as the existing package schema reference
+- Added 12 new package manifests including GUI apps and CLI tools
+- Ran registry validation, release bot dry-runs, and unit tests successfully
+- Adjusted spotify-player checksum handling for nonstandard sidecar naming
+
+**Files:**
+- packages/neovide.toml
+- packages/balenaetcher.toml
+- packages/cargo-binstall.toml
+- packages/goreleaser.toml
+- packages/hammerspoon.toml
+- packages/karabiner-elements.toml
+- packages/linear.toml
+- packages/obsidian-cli.toml
+- packages/obsidian.toml
+- packages/opencode-desktop.toml
+- packages/pearcleaner.toml
+- packages/spotify-player.toml
+- packages/tirith.toml
+
+**Flow:**
+user notes DMG support -> neovide schema reference identified -> GUI and CLI batch added -> validation and dry-runs executed -> tests passed
+
+**Timestamp:** 2026-05-02
+
+**Author:** Ian
+
+## Narrative
+### Structure
+The update belongs with the registry GitHub Actions knowledge because it describes package-manifest content and validation outcomes for the dotfiles package batch.
+
+### Dependencies
+The batch depends on the existing neovide package pattern for DMG and GUI app metadata, plus registry validation and release bot dry-run tooling.
+
+### Highlights
+The registry already models DMG support, and the batch expanded coverage to GUI casks while preserving validation quality. All listed checks passed, indicating the new package manifests were consistent with the registry rules.
+
+### Examples
+Examples of newly added GUI packages include balenaetcher, hammerspoon, karabiner-elements, obsidian, opencode-desktop, and pearcleaner.
+
+## Facts
+- **registry_dmg_support**: The registry supports DMG packages. [project]
+- **schema_reference_package**: neovide is used as the schema reference for GUI casks and DMG metadata. [project]
+- **batch_size**: A second batch added 12 manifests. [project]
+- **added_packages**: The added packages were balenaetcher, cargo-binstall, goreleaser, hammerspoon, karabiner-elements, linear, obsidian-cli, obsidian, opencode-desktop, pearcleaner, spotify-player, and tirith. [project]
+- **validation_status**: Validation passed for registry source configs and manifest checks. [project]
+- **dry_run_status**: Release bot dry-runs passed for all 12 new packages. [project]
+- **test_status**: Python unit tests passed with 62 tests. [project]
+- **spotify_player_checksum_handling**: spotify-player required checksum handling adjustments because its .sha256 sidecars did not follow the {url}.sha256 pattern. [project]
+
+## Supplemental note from registry_package_formats
+- The registry supports dmg artifacts for package publishing.
+- Neovide is a concrete existing example of a package using dmg.
+- Publishing flow: package -> build artifact -> registry publish
+- This note is a durable confirmation of artifact-format support.

--- a/.brv/context-tree/ci/github_actions/registry_quality_gate_and_signing_workflow_fix.md
+++ b/.brv/context-tree/ci/github_actions/registry_quality_gate_and_signing_workflow_fix.md
@@ -2,7 +2,7 @@
 title: Registry Quality Gate and Signing Workflow Fix
 summary: Workflow fix work was done in ./.worktrees/fix-registry-gate-after-signing; origin/main already had the python3 portability change; validation passed with tests.test_github_workflows and full test discovery.
 tags: []
-related: [ci/github_actions/sign_manifests_on_merge.md, ci/github_actions/registry_quality_gate_and_signing_workflow_fix.md]
+related: [ci/github_actions/sign_manifests_on_merge.md, ci/github_actions/registry_quality_gate_and_signing_workflow_fix.md, ci/github_actions/dotfiles_package_batch_for_registry.md]
 keywords: []
 createdAt: '2026-04-26T00:09:44.731Z'
 updatedAt: '2026-04-26T01:33:41.225Z'

--- a/.brv/context-tree/facts/project/workspace_isolation_and_current_worktree.md
+++ b/.brv/context-tree/facts/project/workspace_isolation_and_current_worktree.md
@@ -1,0 +1,59 @@
+---
+title: Workspace Isolation and Current Worktree
+summary: Current session must only use the new worktree at /home/ianpascoe/.kimaki/worktrees/1010908a/package-batch-1 on branch opencode/kimaki-package-batch-1; the previous checkout is out of scope.
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-03T02:11:18.788Z'
+updatedAt: '2026-05-03T02:11:18.788Z'
+consolidated_at: '2026-05-03T02:26:25.932Z'
+consolidated_from:
+  - {date: '2026-05-03T02:26:25.932Z', path: facts/project/workspace_isolation_and_current_worktree.abstract.md, reason: 'These three files describe the same worktree-isolation note with highly overlapping content. The main markdown file is the richest source and already contains the metadata, raw concept, narrative, and facts; the abstract and overview are summaries of the same topic and can be folded into one canonical note.'}
+  - {date: '2026-05-03T02:26:25.932Z', path: facts/project/workspace_isolation_and_current_worktree.overview.md, reason: 'These three files describe the same worktree-isolation note with highly overlapping content. The main markdown file is the richest source and already contains the metadata, raw concept, narrative, and facts; the abstract and overview are summaries of the same topic and can be folded into one canonical note.'}
+---
+## Reason
+Record the enforced worktree isolation and active checkout for this session
+
+## Raw Concept
+**Task:**
+Document workspace isolation constraints for the current session
+
+**Changes:**
+- Restricted file operations to the new worktree path
+- Marked the previous checkout as do-not-touch
+- Captured the active branch name
+
+**Files:**
+- /home/ianpascoe/.kimaki/worktrees/1010908a/package-batch-1
+
+**Flow:**
+cwd change notification -> isolate edits to new worktree -> avoid previous checkout
+
+**Timestamp:** 2026-05-03T02:11:09.557Z
+
+**Author:** user
+
+## Narrative
+### Structure
+This note records repository-scope boundaries for the session rather than product behavior.
+
+### Dependencies
+All future reads and writes must stay under the new worktree; the prior checkout is separate and may be actively edited elsewhere.
+
+### Highlights
+The session moved to /home/ianpascoe/.kimaki/worktrees/1010908a/package-batch-1 on branch opencode/kimaki-package-batch-1.
+
+### Rules
+You MUST read, write, and edit files only under the new folder /home/ianpascoe/.kimaki/worktrees/1010908a/package-batch-1. You MUST NOT read, write, or edit any files under the previous folder /home/ianpascoe/code/crosspack.
+
+## Facts
+- **worktree_isolation**: Future edits in this session must be confined to the new worktree path only. [project]
+- **git_branch**: The active git branch is opencode/kimaki-package-batch-1. [project]
+
+## Consolidated details from companion summaries
+- The session is strictly isolated to the new worktree: `/home/ianpascoe/.kimaki/worktrees/1010908a/package-batch-1`.
+- The previous checkout at `/home/ianpascoe/code/crosspack` is explicitly out of scope and must not be touched.
+- All future read/write/edit operations are constrained to the new worktree only.
+- The note records repository-scope boundaries for the session, not product behavior.
+- The workflow emphasized a transition from cwd change notification to isolated edits in the new worktree.
+- Key entities: worktree path, previous checkout, and active git branch.

--- a/packages/ast-grep.toml
+++ b/packages/ast-grep.toml
@@ -1,0 +1,77 @@
+name = "ast-grep"
+license = "MIT"
+homepage = "https://github.com/ast-grep/ast-grep"
+
+[source.release]
+kind = "github_releases"
+repo = "ast-grep/ast-grep"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "download_sha256"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "app-x86_64-unknown-linux-gnu.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "ast-grep"
+path = "sg"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "app-aarch64-unknown-linux-gnu.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "ast-grep"
+path = "sg"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "app-x86_64-apple-darwin.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "ast-grep"
+path = "sg"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "app-aarch64-apple-darwin.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "ast-grep"
+path = "sg"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "app-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "ast-grep"
+path = "sg.exe"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "app-aarch64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "ast-grep"
+path = "sg.exe"

--- a/packages/balenaetcher.toml
+++ b/packages/balenaetcher.toml
@@ -1,0 +1,80 @@
+name = "balenaetcher"
+license = "Apache-2.0"
+homepage = "https://github.com/balena-io/etcher"
+
+[source.release]
+kind = "github_releases"
+repo = "balena-io/etcher"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "download_sha256"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "balenaEtcher-linux-x64-{version}.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "balenaetcher"
+path = "balenaEtcher.AppImage"
+
+[[artifacts.gui_apps]]
+app_id = "io.balena.etcher"
+display_name = "balenaEtcher"
+exec = "balenaEtcher.AppImage"
+categories = ["Utility"]
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "balenaEtcher-{version}-x64.dmg"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "balenaetcher"
+path = "balenaEtcher.app/Contents/MacOS/balenaEtcher"
+
+[[artifacts.gui_apps]]
+app_id = "io.balena.etcher"
+display_name = "balenaEtcher"
+exec = "balenaEtcher.app"
+categories = ["Utility"]
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "balenaEtcher-{version}-arm64.dmg"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "balenaetcher"
+path = "balenaEtcher.app/Contents/MacOS/balenaEtcher"
+
+[[artifacts.gui_apps]]
+app_id = "io.balena.etcher"
+display_name = "balenaEtcher"
+exec = "balenaEtcher.app"
+categories = ["Utility"]
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "balenaEtcher-win32-x64-{version}.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "balenaetcher"
+path = "balenaEtcher.exe"
+
+[[artifacts.gui_apps]]
+app_id = "io.balena.etcher"
+display_name = "balenaEtcher"
+exec = "balenaEtcher.exe"
+categories = ["Utility"]

--- a/packages/cargo-binstall.toml
+++ b/packages/cargo-binstall.toml
@@ -1,0 +1,78 @@
+name = "cargo-binstall"
+license = "GPL-3.0"
+homepage = "https://github.com/cargo-bins/cargo-binstall"
+
+[source.release]
+kind = "github_releases"
+repo = "cargo-bins/cargo-binstall"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "download_sha256"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "cargo-binstall-x86_64-unknown-linux-gnu.tgz"
+archive = "tgz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "cargo-binstall"
+path = "cargo-binstall"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "cargo-binstall-aarch64-unknown-linux-gnu.tgz"
+archive = "tgz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "cargo-binstall"
+path = "cargo-binstall"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "cargo-binstall-x86_64-apple-darwin.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "cargo-binstall"
+path = "cargo-binstall"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "cargo-binstall-aarch64-apple-darwin.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "cargo-binstall"
+path = "cargo-binstall"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "cargo-binstall-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "cargo-binstall"
+path = "cargo-binstall.exe"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "cargo-binstall-aarch64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "cargo-binstall"
+path = "cargo-binstall.exe"

--- a/packages/chezmoi.toml
+++ b/packages/chezmoi.toml
@@ -1,0 +1,68 @@
+name = "chezmoi"
+license = "MIT"
+homepage = "https://github.com/twpayne/chezmoi"
+
+[source.release]
+kind = "github_releases"
+repo = "twpayne/chezmoi"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "download_sha256"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "chezmoi_{version}_linux-glibc_amd64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "chezmoi"
+path = "chezmoi"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "chezmoi_{version}_linux_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "chezmoi"
+path = "chezmoi"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "chezmoi_{version}_darwin_amd64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "chezmoi"
+path = "chezmoi"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "chezmoi_{version}_darwin_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "chezmoi"
+path = "chezmoi"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "chezmoi_{version}_windows_amd64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "chezmoi"
+path = "chezmoi.exe"

--- a/packages/fastfetch.toml
+++ b/packages/fastfetch.toml
@@ -1,0 +1,67 @@
+name = "fastfetch"
+license = "MIT"
+homepage = "https://github.com/fastfetch-cli/fastfetch"
+
+[source.release]
+kind = "github_releases"
+repo = "fastfetch-cli/fastfetch"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "download_sha256"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "fastfetch-linux-amd64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "fastfetch"
+path = "fastfetch"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "fastfetch-linux-aarch64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "fastfetch"
+path = "fastfetch"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "fastfetch-macos-amd64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "fastfetch"
+path = "fastfetch"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "fastfetch-macos-aarch64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "fastfetch"
+path = "fastfetch"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "fastfetch-windows-amd64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "fastfetch"
+path = "fastfetch.exe"

--- a/packages/goreleaser.toml
+++ b/packages/goreleaser.toml
@@ -1,0 +1,78 @@
+name = "goreleaser"
+license = "MIT"
+homepage = "https://github.com/goreleaser/goreleaser"
+
+[source.release]
+kind = "github_releases"
+repo = "goreleaser/goreleaser"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "download_sha256"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "goreleaser_Linux_x86_64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "goreleaser"
+path = "goreleaser"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "goreleaser_Linux_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "goreleaser"
+path = "goreleaser"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "goreleaser_Darwin_x86_64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "goreleaser"
+path = "goreleaser"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "goreleaser_Darwin_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "goreleaser"
+path = "goreleaser"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "goreleaser_Windows_x86_64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "goreleaser"
+path = "goreleaser.exe"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "goreleaser_Windows_arm64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "goreleaser"
+path = "goreleaser.exe"

--- a/packages/hammerspoon.toml
+++ b/packages/hammerspoon.toml
@@ -1,0 +1,33 @@
+name = "hammerspoon"
+license = "MIT"
+homepage = "https://github.com/Hammerspoon/hammerspoon"
+
+[source.release]
+kind = "github_releases"
+repo = "Hammerspoon/hammerspoon"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "download_sha256"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "Hammerspoon-{version}.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "hammerspoon"
+path = "Hammerspoon.app/Contents/MacOS/Hammerspoon"
+
+[[artifacts.gui_apps]]
+app_id = "org.hammerspoon.Hammerspoon"
+display_name = "Hammerspoon"
+exec = "Hammerspoon.app"
+categories = ["Utility"]

--- a/packages/jj.toml
+++ b/packages/jj.toml
@@ -19,6 +19,7 @@ kind = "release_asset_url"
 
 [[artifacts]]
 target = "x86_64-unknown-linux-gnu"
+# jj only publishes musl Linux archives; use them for the generic Linux targets.
 asset = "jj-v{version}-x86_64-unknown-linux-musl.tar.gz"
 archive = "tar.gz"
 strip_components = 0
@@ -29,6 +30,7 @@ path = "jj"
 
 [[artifacts]]
 target = "aarch64-unknown-linux-gnu"
+# jj only publishes musl Linux archives; use them for the generic Linux targets.
 asset = "jj-v{version}-aarch64-unknown-linux-musl.tar.gz"
 archive = "tar.gz"
 strip_components = 0

--- a/packages/jj.toml
+++ b/packages/jj.toml
@@ -1,0 +1,78 @@
+name = "jj"
+license = "Apache-2.0"
+homepage = "https://github.com/jj-vcs/jj"
+
+[source.release]
+kind = "github_releases"
+repo = "jj-vcs/jj"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "download_sha256"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "jj-v{version}-x86_64-unknown-linux-musl.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "jj"
+path = "jj"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "jj-v{version}-aarch64-unknown-linux-musl.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "jj"
+path = "jj"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "jj-v{version}-x86_64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "jj"
+path = "jj"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "jj-v{version}-aarch64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "jj"
+path = "jj"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "jj-v{version}-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "jj"
+path = "jj.exe"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "jj-v{version}-aarch64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "jj"
+path = "jj.exe"

--- a/packages/karabiner-elements.toml
+++ b/packages/karabiner-elements.toml
@@ -1,0 +1,48 @@
+name = "karabiner-elements"
+license = "Unlicense"
+homepage = "https://github.com/pqrs-org/Karabiner-Elements"
+
+[source.release]
+kind = "github_releases"
+repo = "pqrs-org/Karabiner-Elements"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "download_sha256"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "Karabiner-Elements-{version}.dmg"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "karabiner-elements"
+path = "Karabiner-Elements.app/Contents/MacOS/Karabiner-Elements"
+
+[[artifacts.gui_apps]]
+app_id = "org.pqrs.Karabiner-Elements"
+display_name = "Karabiner-Elements"
+exec = "Karabiner-Elements.app"
+categories = ["Utility"]
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "Karabiner-Elements-{version}.dmg"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "karabiner-elements"
+path = "Karabiner-Elements.app/Contents/MacOS/Karabiner-Elements"
+
+[[artifacts.gui_apps]]
+app_id = "org.pqrs.Karabiner-Elements"
+display_name = "Karabiner-Elements"
+exec = "Karabiner-Elements.app"
+categories = ["Utility"]

--- a/packages/linear.toml
+++ b/packages/linear.toml
@@ -1,0 +1,69 @@
+name = "linear"
+license = "MIT"
+homepage = "https://github.com/schpet/linear-cli"
+
+[source.release]
+kind = "github_releases"
+repo = "schpet/linear-cli"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "url_sha256"
+url_template = "{url}.sha256"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "linear-x86_64-unknown-linux-gnu.tar.xz"
+archive = "tar.xz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "linear"
+path = "linear"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "linear-aarch64-unknown-linux-gnu.tar.xz"
+archive = "tar.xz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "linear"
+path = "linear"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "linear-x86_64-apple-darwin.tar.xz"
+archive = "tar.xz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "linear"
+path = "linear"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "linear-aarch64-apple-darwin.tar.xz"
+archive = "tar.xz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "linear"
+path = "linear"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "linear-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "linear"
+path = "linear.exe"

--- a/packages/lsd.toml
+++ b/packages/lsd.toml
@@ -1,0 +1,68 @@
+name = "lsd"
+license = "Apache-2.0"
+homepage = "https://github.com/lsd-rs/lsd"
+
+[source.release]
+kind = "github_releases"
+repo = "lsd-rs/lsd"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "download_sha256"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "lsd-v{version}-x86_64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "lsd"
+path = "lsd"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "lsd-v{version}-aarch64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "lsd"
+path = "lsd"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "lsd-v{version}-x86_64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "lsd"
+path = "lsd"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "lsd-v{version}-aarch64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "lsd"
+path = "lsd"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "lsd-v{version}-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "lsd"
+path = "lsd.exe"

--- a/packages/mise.toml
+++ b/packages/mise.toml
@@ -1,0 +1,78 @@
+name = "mise"
+license = "MIT"
+homepage = "https://github.com/jdx/mise"
+
+[source.release]
+kind = "github_releases"
+repo = "jdx/mise"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "download_sha256"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "mise-v{version}-linux-x64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "mise"
+path = "mise"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "mise-v{version}-linux-arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "mise"
+path = "mise"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "mise-v{version}-macos-x64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "mise"
+path = "mise"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "mise-v{version}-macos-arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "mise"
+path = "mise"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "mise-v{version}-windows-x64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "mise"
+path = "mise.exe"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "mise-v{version}-windows-arm64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "mise"
+path = "mise.exe"

--- a/packages/neovim.toml
+++ b/packages/neovim.toml
@@ -1,0 +1,78 @@
+name = "neovim"
+license = "Apache-2.0"
+homepage = "https://github.com/neovim/neovim"
+
+[source.release]
+kind = "github_releases"
+repo = "neovim/neovim"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "download_sha256"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "nvim-linux-x86_64.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "nvim"
+path = "bin/nvim"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "nvim-linux-arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "nvim"
+path = "bin/nvim"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "nvim-macos-x86_64.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "nvim"
+path = "bin/nvim"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "nvim-macos-arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "nvim"
+path = "bin/nvim"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "nvim-win64.zip"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "nvim"
+path = "bin/nvim.exe"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "nvim-win-arm64.zip"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "nvim"
+path = "bin/nvim.exe"

--- a/packages/obsidian-cli.toml
+++ b/packages/obsidian-cli.toml
@@ -1,0 +1,78 @@
+name = "obsidian-cli"
+license = "MIT"
+homepage = "https://github.com/Yakitrak/notesmd-cli"
+
+[source.release]
+kind = "github_releases"
+repo = "Yakitrak/notesmd-cli"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "download_sha256"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "notesmd-cli_{version}_linux_amd64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "obsidian-cli"
+path = "notesmd-cli"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "notesmd-cli_{version}_linux_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "obsidian-cli"
+path = "notesmd-cli"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "notesmd-cli_{version}_darwin_all.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "obsidian-cli"
+path = "notesmd-cli"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "notesmd-cli_{version}_darwin_all.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "obsidian-cli"
+path = "notesmd-cli"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "notesmd-cli_{version}_windows_amd64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "obsidian-cli"
+path = "notesmd-cli.exe"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "notesmd-cli_{version}_windows_arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "obsidian-cli"
+path = "notesmd-cli.exe"

--- a/packages/obsidian.toml
+++ b/packages/obsidian.toml
@@ -86,10 +86,10 @@ strip_components = 0
 
 [[artifacts.binaries]]
 name = "obsidian"
-path = "Obsidian-{version}.exe"
+path = "obsidian.exe"
 
 [[artifacts.gui_apps]]
 app_id = "md.obsidian.Obsidian"
 display_name = "Obsidian"
-exec = "Obsidian-{version}.exe"
+exec = "obsidian.exe"
 categories = ["Office", "Utility"]

--- a/packages/obsidian.toml
+++ b/packages/obsidian.toml
@@ -1,0 +1,95 @@
+name = "obsidian"
+license = "Proprietary"
+homepage = "https://github.com/obsidianmd/obsidian-releases"
+
+[source.release]
+kind = "github_releases"
+repo = "obsidianmd/obsidian-releases"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "download_sha256"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "obsidian-{version}.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "obsidian"
+path = "obsidian"
+
+[[artifacts.gui_apps]]
+app_id = "md.obsidian.Obsidian"
+display_name = "Obsidian"
+exec = "obsidian"
+categories = ["Office", "Utility"]
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "obsidian-{version}-arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "obsidian"
+path = "obsidian"
+
+[[artifacts.gui_apps]]
+app_id = "md.obsidian.Obsidian"
+display_name = "Obsidian"
+exec = "obsidian"
+categories = ["Office", "Utility"]
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "Obsidian-{version}.dmg"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "obsidian"
+path = "Obsidian.app/Contents/MacOS/Obsidian"
+
+[[artifacts.gui_apps]]
+app_id = "md.obsidian.Obsidian"
+display_name = "Obsidian"
+exec = "Obsidian.app"
+categories = ["Office", "Utility"]
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "Obsidian-{version}.dmg"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "obsidian"
+path = "Obsidian.app/Contents/MacOS/Obsidian"
+
+[[artifacts.gui_apps]]
+app_id = "md.obsidian.Obsidian"
+display_name = "Obsidian"
+exec = "Obsidian.app"
+categories = ["Office", "Utility"]
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "Obsidian-{version}.exe"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "obsidian"
+path = "Obsidian-{version}.exe"
+
+[[artifacts.gui_apps]]
+app_id = "md.obsidian.Obsidian"
+display_name = "Obsidian"
+exec = "Obsidian-{version}.exe"
+categories = ["Office", "Utility"]

--- a/packages/opencode-desktop.toml
+++ b/packages/opencode-desktop.toml
@@ -1,0 +1,94 @@
+name = "opencode-desktop"
+license = "MIT"
+homepage = "https://github.com/sst/opencode"
+
+[source.release]
+kind = "github_releases"
+repo = "sst/opencode"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "download_sha256"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "opencode-electron-linux-x86_64.AppImage"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "opencode-desktop"
+path = "opencode-electron-linux-x86_64.AppImage"
+
+[[artifacts.gui_apps]]
+app_id = "ai.opencode.desktop"
+display_name = "opencode Desktop"
+exec = "opencode-electron-linux-x86_64.AppImage"
+categories = ["Development", "Utility"]
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "opencode-electron-mac-x64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "opencode-desktop"
+path = "opencode.app/Contents/MacOS/opencode"
+
+[[artifacts.gui_apps]]
+app_id = "ai.opencode.desktop"
+display_name = "opencode Desktop"
+exec = "opencode.app"
+categories = ["Development", "Utility"]
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "opencode-electron-mac-arm64.dmg"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "opencode-desktop"
+path = "opencode.app/Contents/MacOS/opencode"
+
+[[artifacts.gui_apps]]
+app_id = "ai.opencode.desktop"
+display_name = "opencode Desktop"
+exec = "opencode.app"
+categories = ["Development", "Utility"]
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "opencode-electron-win-x64.exe"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "opencode-desktop"
+path = "opencode-electron-win-x64.exe"
+
+[[artifacts.gui_apps]]
+app_id = "ai.opencode.desktop"
+display_name = "opencode Desktop"
+exec = "opencode-electron-win-x64.exe"
+categories = ["Development", "Utility"]
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "opencode-electron-win-arm64.exe"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "opencode-desktop"
+path = "opencode-electron-win-arm64.exe"
+
+[[artifacts.gui_apps]]
+app_id = "ai.opencode.desktop"
+display_name = "opencode Desktop"
+exec = "opencode-electron-win-arm64.exe"
+categories = ["Development", "Utility"]

--- a/packages/opencode-desktop.toml
+++ b/packages/opencode-desktop.toml
@@ -50,7 +50,8 @@ categories = ["Development", "Utility"]
 
 [[artifacts]]
 target = "aarch64-apple-darwin"
-asset = "opencode-electron-mac-arm64.dmg"
+asset = "opencode-electron-mac-arm64.zip"
+archive = "zip"
 strip_components = 0
 
 [[artifacts.binaries]]

--- a/packages/opencode.toml
+++ b/packages/opencode.toml
@@ -1,0 +1,78 @@
+name = "opencode"
+license = "MIT"
+homepage = "https://github.com/sst/opencode"
+
+[source.release]
+kind = "github_releases"
+repo = "sst/opencode"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "download_sha256"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "opencode-linux-x64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "opencode"
+path = "opencode"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "opencode-linux-arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "opencode"
+path = "opencode"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "opencode-darwin-x64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "opencode"
+path = "opencode"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "opencode-darwin-arm64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "opencode"
+path = "opencode"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "opencode-windows-x64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "opencode"
+path = "opencode.exe"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "opencode-windows-arm64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "opencode"
+path = "opencode.exe"

--- a/packages/pearcleaner.toml
+++ b/packages/pearcleaner.toml
@@ -1,0 +1,49 @@
+name = "pearcleaner"
+license = "GPL-3.0"
+homepage = "https://github.com/alienator88/Pearcleaner"
+
+[source.release]
+kind = "github_releases"
+repo = "alienator88/Pearcleaner"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "download_sha256"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "Pearcleaner-intel.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "pearcleaner"
+path = "Pearcleaner.app/Contents/MacOS/Pearcleaner"
+
+[[artifacts.gui_apps]]
+app_id = "com.alienator88.Pearcleaner"
+display_name = "Pearcleaner"
+exec = "Pearcleaner.app"
+categories = ["Utility"]
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "Pearcleaner-arm.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "pearcleaner"
+path = "Pearcleaner.app/Contents/MacOS/Pearcleaner"
+
+[[artifacts.gui_apps]]
+app_id = "com.alienator88.Pearcleaner"
+display_name = "Pearcleaner"
+exec = "Pearcleaner.app"
+categories = ["Utility"]

--- a/packages/spotify-player.toml
+++ b/packages/spotify-player.toml
@@ -1,0 +1,58 @@
+name = "spotify-player"
+license = "MIT"
+homepage = "https://github.com/aome510/spotify-player"
+
+[source.release]
+kind = "github_releases"
+repo = "aome510/spotify-player"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "download_sha256"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "spotify_player-x86_64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "spotify_player"
+path = "spotify_player"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "spotify_player-x86_64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "spotify_player"
+path = "spotify_player"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "spotify_player-aarch64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "spotify_player"
+path = "spotify_player"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "spotify_player-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "spotify_player"
+path = "spotify_player.exe"

--- a/packages/stylua.toml
+++ b/packages/stylua.toml
@@ -1,0 +1,68 @@
+name = "stylua"
+license = "MPL-2.0"
+homepage = "https://github.com/JohnnyMorganz/StyLua"
+
+[source.release]
+kind = "github_releases"
+repo = "JohnnyMorganz/StyLua"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "download_sha256"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "stylua-linux-x86_64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "stylua"
+path = "stylua"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "stylua-linux-aarch64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "stylua"
+path = "stylua"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "stylua-macos-x86_64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "stylua"
+path = "stylua"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "stylua-macos-aarch64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "stylua"
+path = "stylua"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "stylua-windows-x86_64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "stylua"
+path = "stylua.exe"

--- a/packages/tirith.toml
+++ b/packages/tirith.toml
@@ -1,0 +1,68 @@
+name = "tirith"
+license = "MIT"
+homepage = "https://github.com/sheeki03/tirith"
+
+[source.release]
+kind = "github_releases"
+repo = "sheeki03/tirith"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "download_sha256"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "tirith-x86_64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "tirith"
+path = "tirith"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "tirith-aarch64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "tirith"
+path = "tirith"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "tirith-x86_64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "tirith"
+path = "tirith"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "tirith-aarch64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "tirith"
+path = "tirith"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "tirith-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "tirith"
+path = "tirith.exe"

--- a/packages/yazi.toml
+++ b/packages/yazi.toml
@@ -1,0 +1,96 @@
+name = "yazi"
+license = "MIT"
+homepage = "https://github.com/sxyazi/yazi"
+
+[source.release]
+kind = "github_releases"
+repo = "sxyazi/yazi"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "download_sha256"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "yazi-x86_64-unknown-linux-gnu.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "yazi"
+path = "yazi"
+[[artifacts.binaries]]
+name = "ya"
+path = "ya"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "yazi-aarch64-unknown-linux-gnu.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "yazi"
+path = "yazi"
+[[artifacts.binaries]]
+name = "ya"
+path = "ya"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "yazi-x86_64-apple-darwin.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "yazi"
+path = "yazi"
+[[artifacts.binaries]]
+name = "ya"
+path = "ya"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "yazi-aarch64-apple-darwin.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "yazi"
+path = "yazi"
+[[artifacts.binaries]]
+name = "ya"
+path = "ya"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "yazi-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "yazi"
+path = "yazi.exe"
+[[artifacts.binaries]]
+name = "ya"
+path = "ya.exe"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "yazi-aarch64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "yazi"
+path = "yazi.exe"
+[[artifacts.binaries]]
+name = "ya"
+path = "ya.exe"

--- a/packages/yt-dlp.toml
+++ b/packages/yt-dlp.toml
@@ -47,6 +47,16 @@ name = "yt-dlp"
 path = "yt-dlp_macos"
 
 [[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "yt-dlp_macos"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "yt-dlp"
+path = "yt-dlp_macos"
+
+[[artifacts]]
 target = "x86_64-pc-windows-msvc"
 asset = "yt-dlp.exe"
 archive = "bin"

--- a/packages/yt-dlp.toml
+++ b/packages/yt-dlp.toml
@@ -1,0 +1,67 @@
+name = "yt-dlp"
+license = "Unlicense"
+homepage = "https://github.com/yt-dlp/yt-dlp"
+
+[source.release]
+kind = "github_releases"
+repo = "yt-dlp/yt-dlp"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "download_sha256"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "yt-dlp_linux"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "yt-dlp"
+path = "yt-dlp_linux"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "yt-dlp_linux_aarch64"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "yt-dlp"
+path = "yt-dlp_linux_aarch64"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "yt-dlp_macos"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "yt-dlp"
+path = "yt-dlp_macos"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "yt-dlp.exe"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "yt-dlp"
+path = "yt-dlp.exe"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "yt-dlp_arm64.exe"
+archive = "bin"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "yt-dlp"
+path = "yt-dlp_arm64.exe"


### PR DESCRIPTION
## Summary
- Add 23 package manifests sourced from Ian's dotfiles, including developer CLIs and GUI apps.
- Include GUI metadata for DMG, AppImage, app bundle, and Windows executable package entries where supported by existing registry schema.
- Add ByteRover context in a separate docs commit for traceability.

## Validation
- `python3 scripts/registry-validate-source.py packages/*.toml`
- `python3 scripts/registry-validate.py --allow-missing-signatures packages/*.toml releases/*/*.toml`
- `python3 -m unittest discover tests`

## Notes
- Signature sidecars are intentionally absent for new package manifests and should be generated by the merge signing workflow.