### PR TITLE
fix(registry): restore valid metadata state

### DIFF
--- a/.github/workflows/registry-quality-gate.yml
+++ b/.github/workflows/registry-quality-gate.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'packages/*.toml'
       - 'packages/*.toml.sig'
+      - 'releases/**'
       - 'releases/**/*.toml'
       - 'releases/**/*.toml.sig'
       - 'scripts/**'

--- a/packages/jj.toml
+++ b/packages/jj.toml
@@ -19,6 +19,7 @@ kind = "release_asset_url"
 
 [[artifacts]]
 target = "x86_64-unknown-linux-gnu"
+# jj only publishes musl Linux archives; use them for the generic Linux targets.
 asset = "jj-v{version}-x86_64-unknown-linux-musl.tar.gz"
 archive = "tar.gz"
 strip_components = 0
@@ -29,6 +30,7 @@ path = "jj"
 
 [[artifacts]]
 target = "aarch64-unknown-linux-gnu"
+# jj only publishes musl Linux archives; use them for the generic Linux targets.
 asset = "jj-v{version}-aarch64-unknown-linux-musl.tar.gz"
 archive = "tar.gz"
 strip_components = 0

--- a/scripts/registry-validate.py
+++ b/scripts/registry-validate.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 import argparse
 import re
+import subprocess
 import sys
+import tempfile
 import tomllib
 from pathlib import Path
 
@@ -296,6 +298,13 @@ def validate_package_manifest(path: Path, doc: dict, errors: list[str]) -> None:
                 path,
                 f"package filename `{file_pkg}` does not match `name` `{doc['name']}`",
             )
+        release_dir = path.parent.parent / "releases" / file_pkg
+        if not release_dir.is_dir():
+            err(
+                errors,
+                path,
+                f"missing release directory `{release_dir.as_posix()}` for package template",
+            )
 
     artifacts = doc.get("artifacts")
     if not isinstance(artifacts, list) or not artifacts:
@@ -460,7 +469,9 @@ def validate_release_manifest(path: Path, doc: dict, errors: list[str]) -> None:
             err(errors, path, f"{prefix}.sha256 must be 64 hex characters")
 
 
-def validate_signature_sidecar(path: Path, errors: list[str]) -> None:
+def validate_signature_sidecar(
+    path: Path, errors: list[str], trusted_key_path: Path | None
+) -> None:
     sig_path = path.with_suffix(path.suffix + ".sig")
     if not sig_path.exists():
         err(errors, path, f"missing signature sidecar `{sig_path.name}`")
@@ -478,9 +489,88 @@ def validate_signature_sidecar(path: Path, errors: list[str]) -> None:
             path,
             f"invalid signature format in `{sig_path.name}` (expected 128 hex characters)",
         )
+        return
+
+    if trusted_key_path is not None:
+        verify_signature(path, sig_path, sig_raw, trusted_key_path, errors)
 
 
-def validate_manifest(path: Path, errors: list[str], require_signatures: bool) -> None:
+def verify_signature(
+    path: Path, sig_path: Path, sig_raw: str, trusted_key_path: Path, errors: list[str]
+) -> None:
+    try:
+        public_key_hex = trusted_key_path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        err(errors, path, f"cannot read trusted registry key `{trusted_key_path}` ({exc})")
+        return
+
+    if not re.fullmatch(r"^[0-9a-fA-F]{64}$", public_key_hex):
+        err(errors, trusted_key_path, "trusted registry key must be 64 hex characters")
+        return
+
+    try:
+        # RFC 8410 Ed25519 SubjectPublicKeyInfo prefix followed by the 32-byte raw key.
+        public_der = bytes.fromhex("302a300506032b6570032100" + public_key_hex)
+        signature_bytes = bytes.fromhex(sig_raw)
+    except ValueError as exc:
+        err(errors, path, f"cannot decode signature verification material ({exc})")
+        return
+
+    with tempfile.TemporaryDirectory(prefix="registry-validate-sig-") as tmp:
+        tmp_path = Path(tmp)
+        public_der_path = tmp_path / "registry.pub.der"
+        public_pem_path = tmp_path / "registry.pub.pem"
+        signature_bin_path = tmp_path / sig_path.name
+        public_der_path.write_bytes(public_der)
+        signature_bin_path.write_bytes(signature_bytes)
+
+        convert = subprocess.run(
+            [
+                "openssl",
+                "pkey",
+                "-pubin",
+                "-inform",
+                "DER",
+                "-in",
+                str(public_der_path),
+                "-out",
+                str(public_pem_path),
+            ],
+            text=True,
+            capture_output=True,
+        )
+        if convert.returncode != 0:
+            err(errors, trusted_key_path, f"cannot load trusted registry key ({convert.stderr.strip()})")
+            return
+
+        verify = subprocess.run(
+            [
+                "openssl",
+                "pkeyutl",
+                "-verify",
+                "-rawin",
+                "-pubin",
+                "-inkey",
+                str(public_pem_path),
+                "-sigfile",
+                str(signature_bin_path),
+                "-in",
+                str(path),
+            ],
+            text=True,
+            capture_output=True,
+        )
+        if verify.returncode != 0:
+            detail = verify.stderr.strip() or verify.stdout.strip() or "signature verification failed"
+            err(errors, path, f"invalid signature sidecar `{sig_path.name}` ({detail})")
+
+
+def validate_manifest(
+    path: Path,
+    errors: list[str],
+    require_signatures: bool,
+    trusted_key_path: Path | None,
+) -> None:
     doc = load_manifest(path, errors)
     if doc is None:
         return
@@ -501,7 +591,7 @@ def validate_manifest(path: Path, errors: list[str], require_signatures: bool) -
         )
 
     if require_signatures:
-        validate_signature_sidecar(path, errors)
+        validate_signature_sidecar(path, errors, trusted_key_path)
 
 
 def main() -> int:
@@ -513,16 +603,23 @@ def main() -> int:
         action="store_true",
         help="Skip required .toml.sig sidecar checks (for PR pre-merge validation)",
     )
+    parser.add_argument(
+        "--trusted-key",
+        default="registry.pub",
+        help="Trusted registry public key used to verify .toml.sig sidecars",
+    )
     parser.add_argument("manifests", nargs="+", help="Manifest paths to validate")
     args = parser.parse_args()
 
     errors: list[str] = []
     manifest_paths = [Path(p) for p in args.manifests]
+    trusted_key_path = None if args.allow_missing_signatures else Path(args.trusted_key)
     for path in manifest_paths:
         validate_manifest(
             path,
             errors,
             require_signatures=not args.allow_missing_signatures,
+            trusted_key_path=trusted_key_path,
         )
 
     if errors:
@@ -537,7 +634,7 @@ def main() -> int:
         )
     else:
         print(
-            f"Validated {len(manifest_paths)} manifest(s): package/release schema, checksum, and signature format checks passed."
+            f"Validated {len(manifest_paths)} manifest(s): package/release schema, checksum, and signature verification checks passed."
         )
     return 0
 

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -16,6 +16,7 @@ class GitHubWorkflowTests(unittest.TestCase):
         self.assertIn("      - Sign Manifests On Merge", quality_gate)
         self.assertIn("      - completed", quality_gate)
         self.assertIn("      - main", quality_gate)
+        self.assertIn("      - 'releases/**'", quality_gate)
 
     def test_registry_quality_gate_workflow_run_uses_changed_manifests(self) -> None:
         quality_gate = (

--- a/tests/test_registry_validate.py
+++ b/tests/test_registry_validate.py
@@ -117,6 +117,144 @@ class RegistryValidateTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("does not match `name`", result.stderr)
 
+    def test_package_without_release_directory_fails(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="registry-validate-") as tmp:
+            tmp_path = Path(tmp)
+            package = tmp_path / "packages" / "demo.toml"
+            package.parent.mkdir(parents=True, exist_ok=True)
+            package.write_text(
+                textwrap.dedent(
+                    """
+                    name = "demo"
+                    license = "MIT"
+                    homepage = "https://example.com/demo"
+
+                    [source]
+                    provider = "github"
+                    repo = "example/demo"
+
+                    [[artifacts]]
+                    target = "x86_64-unknown-linux-gnu"
+                    asset = "demo-{version}.tar.gz"
+                    archive = "tar.gz"
+
+                    [[artifacts.binaries]]
+                    name = "demo"
+                    path = "demo"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                ["python3", str(SCRIPT), "--allow-missing-signatures", str(package)],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("missing release directory", result.stderr)
+
+    def test_invalid_signature_fails(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="registry-validate-") as tmp:
+            tmp_path = Path(tmp)
+            key_path = tmp_path / "signing-key.pem"
+            registry_pub_path = tmp_path / "registry.pub"
+            package = tmp_path / "packages" / "demo.toml"
+            release_dir = tmp_path / "releases" / "demo"
+            package.parent.mkdir(parents=True, exist_ok=True)
+            release_dir.mkdir(parents=True, exist_ok=True)
+            package.write_text(
+                textwrap.dedent(
+                    """
+                    name = "demo"
+                    license = "MIT"
+                    homepage = "https://example.com/demo"
+
+                    [source]
+                    provider = "github"
+                    repo = "example/demo"
+
+                    [[artifacts]]
+                    target = "x86_64-unknown-linux-gnu"
+                    asset = "demo-{version}.tar.gz"
+                    archive = "tar.gz"
+
+                    [[artifacts.binaries]]
+                    name = "demo"
+                    path = "demo"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            subprocess.run(
+                ["openssl", "genpkey", "-algorithm", "ed25519", "-out", str(key_path)],
+                cwd=tmp_path,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            pub_der = subprocess.run(
+                [
+                    "openssl",
+                    "pkey",
+                    "-in",
+                    str(key_path),
+                    "-pubout",
+                    "-outform",
+                    "DER",
+                ],
+                cwd=tmp_path,
+                capture_output=True,
+                check=True,
+            ).stdout
+            registry_pub_path.write_text(pub_der[-32:].hex() + "\n", encoding="utf-8")
+
+            other = tmp_path / "other.toml"
+            other.write_text(package.read_text(encoding="utf-8") + "# changed\n", encoding="utf-8")
+            sig_bin = tmp_path / "demo.sig.bin"
+            subprocess.run(
+                [
+                    "openssl",
+                    "pkeyutl",
+                    "-sign",
+                    "-rawin",
+                    "-inkey",
+                    str(key_path),
+                    "-in",
+                    str(other),
+                    "-out",
+                    str(sig_bin),
+                ],
+                cwd=tmp_path,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            package.with_suffix(".toml.sig").write_text(
+                sig_bin.read_bytes().hex() + "\n", encoding="utf-8"
+            )
+
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(SCRIPT),
+                    "--trusted-key",
+                    str(registry_pub_path),
+                    str(package),
+                ],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("invalid signature sidecar", result.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Restore signed `jj.toml` bytes so the existing sidecar signature verifies again.
- Add the missing `releases/opencode/` directory placeholder so `opencode.toml` is not treated as an orphaned package template.
- Strengthen the registry quality gate to fail on orphaned package templates and cryptographically invalid `.toml.sig` sidecars.

## Verification
- `python3 -m unittest tests.test_registry_validate tests.test_github_workflows`
- `REGISTRY_PREFLIGHT_ALL=1 REGISTRY_PREFLIGHT_SKIP_SMOKE=1 ./scripts/registry-preflight.sh`
- `cargo run -q -p crosspack-cli --bin crosspack -- --registry-root registry search ''`
- Isolated filesystem source `crosspack update` returned `update summary: updated=0 up-to-date=1 failed=0`