### PR TITLE
fix(registry): correct syncthing service integration

### DIFF
--- a/packages/syncthing.toml
+++ b/packages/syncthing.toml
@@ -20,7 +20,7 @@ kind = "release_asset_url"
 [[integrations]]
 kind = "service"
 name = "syncthing"
-source = "etc/linux-systemd/system/syncthing.service"
+source = "etc/linux-systemd/user/syncthing.service"
 enable = false
 
 [[artifacts]]

--- a/releases/syncthing/2.0.16.toml
+++ b/releases/syncthing/2.0.16.toml
@@ -4,7 +4,7 @@ version = "2.0.16"
 [[integrations]]
 kind = "service"
 name = "syncthing"
-source = "etc/linux-systemd/system/syncthing.service"
+source = "etc/linux-systemd/user/syncthing.service"
 enable = false
 
 [[artifacts]]

--- a/scripts/registry-smoke-install.py
+++ b/scripts/registry-smoke-install.py
@@ -93,6 +93,27 @@ def choose_artifact(
     return artifacts[0]
 
 
+def package_template_path_for_release(path: Path, doc: dict) -> Path | None:
+    name = doc.get("name")
+    if not isinstance(name, str) or not name.strip():
+        return None
+    if path.parent.parent.name != "releases":
+        return None
+    return path.parent.parent.parent / "packages" / f"{name}.toml"
+
+
+def artifact_layout_from_package_template(path: Path, doc: dict, target: str) -> dict:
+    package_template_path = package_template_path_for_release(path, doc)
+    if package_template_path is None or not package_template_path.exists():
+        return {}
+
+    package_doc = tomllib.loads(package_template_path.read_text(encoding="utf-8"))
+    for artifact in package_doc.get("artifacts", []):
+        if artifact.get("target") == target:
+            return artifact
+    return {}
+
+
 DOWNLOAD_ATTEMPTS = 3
 TRANSIENT_HTTP_STATUS_CODES = {408, 429, 500, 502, 503, 504}
 
@@ -233,11 +254,14 @@ def smoke_manifest(
         )
 
     artifact_target = artifact.get("target", "unknown")
+    artifact_layout = artifact_layout_from_package_template(path, doc, artifact_target)
     url = artifact["url"]
     expected_sha = artifact["sha256"].lower()
-    archive = artifact.get("archive")
-    strip_components = int(artifact.get("strip_components", 0))
-    binaries = artifact.get("binaries", [])
+    archive = artifact.get("archive", artifact_layout.get("archive"))
+    strip_components = int(
+        artifact.get("strip_components", artifact_layout.get("strip_components", 0))
+    )
+    binaries = artifact.get("binaries", artifact_layout.get("binaries", []))
 
     with tempfile.TemporaryDirectory(prefix="registry-smoke-") as tmp:
         tmpdir = Path(tmp)
@@ -308,6 +332,27 @@ def smoke_manifest(
                     f"missing extracted binaries for target={artifact_target}: {missing_csv}",
                     failing_binary=missing_csv,
                     hint="verify artifacts[].binaries[].path and strip_components against the extracted archive layout",
+                ),
+            )
+
+        missing_integrations = []
+        for integration in doc.get("integrations", []):
+            source = integration.get("source")
+            if not isinstance(source, str) or not source.strip():
+                continue
+            source_path = install_root / Path(source)
+            if not source_path.exists() or not source_path.is_file():
+                missing_integrations.append(source)
+
+        if missing_integrations:
+            missing_csv = ", ".join(missing_integrations)
+            return (
+                False,
+                failure_message(
+                    path,
+                    package_id,
+                    f"missing extracted integration sources for target={artifact_target}: {missing_csv}",
+                    hint="verify integrations[].source and strip_components against the extracted archive layout",
                 ),
             )
 

--- a/scripts/registry-smoke-install.py
+++ b/scripts/registry-smoke-install.py
@@ -114,6 +114,19 @@ def artifact_layout_from_package_template(path: Path, doc: dict, target: str) ->
     return {}
 
 
+def integrations_from_manifest_or_package_template(path: Path, doc: dict) -> list[dict]:
+    integrations = doc.get("integrations", [])
+    if integrations:
+        return integrations
+
+    package_template_path = package_template_path_for_release(path, doc)
+    if package_template_path is None or not package_template_path.exists():
+        return []
+
+    package_doc = tomllib.loads(package_template_path.read_text(encoding="utf-8"))
+    return package_doc.get("integrations", [])
+
+
 DOWNLOAD_ATTEMPTS = 3
 TRANSIENT_HTTP_STATUS_CODES = {408, 429, 500, 502, 503, 504}
 
@@ -336,7 +349,7 @@ def smoke_manifest(
             )
 
         missing_integrations = []
-        for integration in doc.get("integrations", []):
+        for integration in integrations_from_manifest_or_package_template(path, doc):
             source = integration.get("source")
             if not isinstance(source, str) or not source.strip():
                 continue

--- a/tests/test_registry_smoke_install.py
+++ b/tests/test_registry_smoke_install.py
@@ -3,6 +3,7 @@ import importlib.util
 import io
 import urllib.error
 import tempfile
+import tarfile
 import textwrap
 import unittest
 import zipfile
@@ -153,6 +154,76 @@ class RegistrySmokeInstallTests(unittest.TestCase):
         self.assertTrue(ok)
         self.assertIn("demo@1.0.0", message)
         self.assertIn("target=fallback-target", message)
+
+    def test_release_manifest_uses_package_template_integrations(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="smoke-test-") as tmp:
+            tmp_path = Path(tmp)
+            payload_path = tmp_path / "demo.tar.gz"
+            payload_root = tmp_path / "payload-root"
+            (payload_root / "demo-1.0.0" / "bin").mkdir(parents=True)
+            (payload_root / "demo-1.0.0" / "etc").mkdir(parents=True)
+            (payload_root / "demo-1.0.0" / "bin" / "demo").write_bytes(b"demo")
+            (payload_root / "demo-1.0.0" / "etc" / "demo.service").write_text(
+                "[Service]\n",
+                encoding="utf-8",
+            )
+            with tarfile.open(payload_path, "w:gz") as tf:
+                tf.add(payload_root / "demo-1.0.0", arcname="demo-1.0.0")
+            payload_bytes = payload_path.read_bytes()
+            payload_sha = hashlib.sha256(payload_bytes).hexdigest()
+
+            packages_dir = tmp_path / "packages"
+            releases_dir = tmp_path / "releases" / "demo"
+            packages_dir.mkdir()
+            releases_dir.mkdir(parents=True)
+            (packages_dir / "demo.toml").write_text(
+                textwrap.dedent(
+                    """
+                    name = "demo"
+
+                    [[integrations]]
+                    kind = "service"
+                    name = "demo"
+                    source = "etc/demo.service"
+
+                    [[artifacts]]
+                    target = "fallback-target"
+                    archive = "tar.gz"
+                    strip_components = 1
+
+                    [[artifacts.binaries]]
+                    name = "demo"
+                    path = "bin/demo"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            manifest_path = releases_dir / "1.0.0.toml"
+            manifest_path.write_text(
+                textwrap.dedent(
+                    f"""
+                    name = "demo"
+                    version = "1.0.0"
+
+                    [[artifacts]]
+                    target = "fallback-target"
+                    url = "https://example.invalid/demo.tar.gz"
+                    sha256 = "{payload_sha}"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            def fake_download(_url: str, dest: Path) -> None:
+                dest.write_bytes(payload_bytes)
+
+            with mock.patch.object(self.smoke, "download", side_effect=fake_download):
+                ok, message = self.smoke.smoke_manifest(manifest_path)
+
+        self.assertTrue(ok, msg=message)
+        self.assertIn("demo@1.0.0", message)
 
     def test_download_retries_transient_http_error(self) -> None:
         with tempfile.TemporaryDirectory(prefix="smoke-test-") as tmp:


### PR DESCRIPTION
## Summary
- Point Syncthing service integration at the shipped systemd user unit
- Teach smoke-install checks to validate declared integration source files after extraction
- Reuse package-template artifact layout when smoke-testing release manifests

## Verification
- python3 scripts/registry-validate.py --allow-missing-signatures packages/syncthing.toml releases/syncthing/2.0.16.toml
- python3 scripts/registry-smoke-install.py releases/syncthing/2.0.16.toml