### PR TITLE
feat(registry): add typed integration smoke metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Official Crosspack registry source.
   - package identity (`name`, `license`, `homepage`)
   - upstream source metadata (`[source]`)
   - artifact template metadata (`target`, `asset`, archive hints, binaries/completions/gui metadata)
+  - typed host integrations (`docker_cli_plugin`, `path_plugin`, or `service`) without arbitrary install scripts
 - `releases/<package>/<version>.toml` stores version-specific resolved artifact data:
   - `name`, `version`
   - per-target `url` + `sha256`
@@ -78,6 +79,14 @@ Current supported strategies:
   - `kind = "templated"` with `base_url` for deterministic URL construction from artifact templates
 
 Legacy `provider = "github"` and `provider = "nodejs-dist"` source definitions are still normalized by tooling for compatibility during migration, but new configs should prefer the generalized `[source.release]`, `[source.version]`, `[source.checksum]`, and `[source.asset]` tables.
+
+### Typed host integrations
+
+`[[integrations]]` entries declare host-visible integration metadata. Sources are artifact-relative paths and must not be absolute or contain `..` segments.
+
+- `kind = "docker_cli_plugin"` requires `name` and `source`; install projects the source under the Crosspack prefix, while host activation is explicit through `crosspack integrations enable`.
+- `kind = "path_plugin"` requires `host`, `name`, and `source`; install projects the source under the Crosspack prefix, while host activation is explicit through `crosspack integrations enable`.
+- `kind = "service"` requires `name` and at least one service source: legacy `source`/`linux_systemd_user`, `macos_launch_agent`, or `windows_service`. Service host activation is explicit-only today; registry entries should not set `enable = true`.
 
 Useful commands:
 

--- a/packages/syncthing.toml
+++ b/packages/syncthing.toml
@@ -20,8 +20,9 @@ kind = "release_asset_url"
 [[integrations]]
 kind = "service"
 name = "syncthing"
-source = "etc/linux-systemd/user/syncthing.service"
-enable = false
+linux_systemd_user = "etc/linux-systemd/user/syncthing.service"
+macos_launch_agent = "etc/macos-launchd/user/syncthing.plist"
+windows_service = "etc/windows-service/syncthing.xml"
 
 [[artifacts]]
 target = "x86_64-unknown-linux-gnu"

--- a/releases/syncthing/2.0.16.toml
+++ b/releases/syncthing/2.0.16.toml
@@ -4,8 +4,9 @@ version = "2.0.16"
 [[integrations]]
 kind = "service"
 name = "syncthing"
-source = "etc/linux-systemd/user/syncthing.service"
-enable = false
+linux_systemd_user = "etc/linux-systemd/user/syncthing.service"
+macos_launch_agent = "etc/macos-launchd/user/syncthing.plist"
+windows_service = "etc/windows-service/syncthing.xml"
 
 [[artifacts]]
 target = "x86_64-unknown-linux-gnu"

--- a/scripts/registry-validate.py
+++ b/scripts/registry-validate.py
@@ -24,6 +24,7 @@ VERSION_KIND_VALUES = {"asset_name_regex", "github_tag", "prefixed_semver_field"
 CHECKSUM_KIND_VALUES = {"asset_digest", "download_sha256", "download_index", "shasums256", "url_sha256"}
 ASSET_KIND_VALUES = {"json_index_asset", "release_asset_url", "templated"}
 INTEGRATION_KIND_VALUES = {"docker_cli_plugin", "path_plugin", "service"}
+SERVICE_SOURCE_FIELDS = {"source", "linux_systemd_user", "macos_launch_agent", "windows_service"}
 
 
 def err(errors: list[str], path: Path, message: str) -> None:
@@ -47,9 +48,17 @@ def expect_nonempty_str(value, field: str, errors: list[str], path: Path) -> boo
     return True
 
 
-def is_relative_without_parent_segments(value: str) -> bool:
-    candidate = Path(value)
-    return not candidate.is_absolute() and ".." not in candidate.parts
+def is_safe_relative_source_path(value: str) -> bool:
+    if (
+        not value
+        or value == "."
+        or value.startswith(("/", "\\", "./"))
+        or "\\" in value
+        or re.match(r"^[A-Za-z]:", value)
+        or any(ord(ch) < 32 or ord(ch) == 127 for ch in value)
+    ):
+        return False
+    return all(part not in {"", ".", ".."} for part in value.split("/"))
 
 
 def validate_common_artifact_template_fields(
@@ -92,11 +101,25 @@ def validate_integrations(path: Path, doc: dict, errors: list[str]) -> None:
         if not isinstance(kind, str) or kind not in INTEGRATION_KIND_VALUES:
             err(errors, path, f"{prefix}.kind must be a supported integration kind")
             continue
-        source = integration.get("source")
-        if not isinstance(source, str) or not source.strip():
-            err(errors, path, f"{prefix}.source must be a non-empty string")
-        elif not is_relative_without_parent_segments(source):
-            err(errors, path, f"{prefix}.source must be relative and must not contain '..'")
+        if kind == "service":
+            service_sources = [
+                (field, integration.get(field))
+                for field in sorted(SERVICE_SOURCE_FIELDS)
+                if integration.get(field) is not None
+            ]
+            if not service_sources:
+                err(errors, path, f"{prefix} must declare at least one service source")
+            for field, source in service_sources:
+                if not isinstance(source, str) or not source.strip():
+                    err(errors, path, f"{prefix}.{field} must be a non-empty string")
+                elif not is_safe_relative_source_path(source):
+                    err(errors, path, f"{prefix}.{field} must be a normalized relative path")
+        else:
+            source = integration.get("source")
+            if not isinstance(source, str) or not source.strip():
+                err(errors, path, f"{prefix}.source must be a non-empty string")
+            elif not is_safe_relative_source_path(source):
+                err(errors, path, f"{prefix}.source must be a normalized relative path")
         name = integration.get("name")
         if not isinstance(name, str) or not name.strip():
             err(errors, path, f"{prefix}.name must be a non-empty string")
@@ -344,7 +367,7 @@ def validate_package_manifest(path: Path, doc: dict, errors: list[str]) -> None:
                     err(errors, path, f"{bprefix}.name must be a non-empty string")
                 if not isinstance(bpath, str) or not bpath.strip():
                     err(errors, path, f"{bprefix}.path must be a non-empty string")
-                elif not is_relative_without_parent_segments(bpath):
+                elif not is_safe_relative_source_path(bpath):
                     err(
                         errors,
                         path,
@@ -368,7 +391,7 @@ def validate_package_manifest(path: Path, doc: dict, errors: list[str]) -> None:
                 completion_path = completion.get("path")
                 if not isinstance(completion_path, str) or not completion_path.strip():
                     err(errors, path, f"{cprefix}.path must be a non-empty string")
-                elif not is_relative_without_parent_segments(completion_path):
+                elif not is_safe_relative_source_path(completion_path):
                     err(
                         errors,
                         path,

--- a/tests/test_registry_validate.py
+++ b/tests/test_registry_validate.py
@@ -1,3 +1,4 @@
+import json
 import subprocess
 import tempfile
 import textwrap
@@ -85,6 +86,131 @@ class RegistryValidateTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertIn("Validated 2 manifest(s)", result.stdout)
+
+    def test_service_integration_platform_sources_pass(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="registry-validate-") as tmp:
+            tmp_path = Path(tmp)
+            package = tmp_path / "packages" / "demo.toml"
+            release = tmp_path / "releases" / "demo" / "1.2.3.toml"
+            package.parent.mkdir(parents=True, exist_ok=True)
+            release.parent.mkdir(parents=True, exist_ok=True)
+
+            package.write_text(
+                textwrap.dedent(
+                    """
+                    name = "demo"
+                    license = "MIT"
+                    homepage = "https://example.com/demo"
+
+                    [[integrations]]
+                    kind = "service"
+                    name = "demo"
+                    linux_systemd_user = "etc/linux-systemd/user/demo.service"
+                    macos_launch_agent = "etc/macos-launchd/user/demo.plist"
+                    windows_service = "etc/windows-service/demo.xml"
+
+                    [source]
+                    provider = "github"
+                    repo = "example/demo"
+
+                    [[artifacts]]
+                    target = "x86_64-unknown-linux-gnu"
+                    asset = "demo-{version}.tar.gz"
+                    archive = "tar.gz"
+
+                    [[artifacts.binaries]]
+                    name = "demo"
+                    path = "demo"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            release.write_text(
+                textwrap.dedent(
+                    """
+                    name = "demo"
+                    version = "1.2.3"
+
+                    [[integrations]]
+                    kind = "service"
+                    name = "demo"
+                    linux_systemd_user = "etc/linux-systemd/user/demo.service"
+                    macos_launch_agent = "etc/macos-launchd/user/demo.plist"
+                    windows_service = "etc/windows-service/demo.xml"
+
+                    [[artifacts]]
+                    target = "x86_64-unknown-linux-gnu"
+                    url = "https://example.com/demo-1.2.3.tar.gz"
+                    sha256 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                ["python3", str(SCRIPT), "--allow-missing-signatures", str(package), str(release)],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+            )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+    def test_integration_sources_reject_unsafe_paths(self) -> None:
+        invalid_paths = [
+            ".",
+            "etc//demo.service",
+            "./etc/demo.service",
+            "etc\\demo.service",
+            "C:/etc/demo.service",
+            "etc/demo\x07.service",
+            "../etc/demo.service",
+        ]
+        for invalid_path in invalid_paths:
+            with self.subTest(invalid_path=invalid_path):
+                with tempfile.TemporaryDirectory(prefix="registry-validate-") as tmp:
+                    tmp_path = Path(tmp)
+                    package = tmp_path / "packages" / "demo.toml"
+                    package.parent.mkdir(parents=True, exist_ok=True)
+                    source_literal = json.dumps(invalid_path)
+                    package.write_text(
+                        textwrap.dedent(
+                            f"""
+                            name = "demo"
+                            license = "MIT"
+                            homepage = "https://example.com/demo"
+
+                            [[integrations]]
+                            kind = "service"
+                            name = "demo"
+                            linux_systemd_user = {source_literal}
+
+                            [source]
+                            provider = "github"
+                            repo = "example/demo"
+
+                            [[artifacts]]
+                            target = "x86_64-unknown-linux-gnu"
+                            asset = "demo-{{version}}.tar.gz"
+                            archive = "tar.gz"
+                            """
+                        ).strip()
+                        + "\n",
+                        encoding="utf-8",
+                    )
+
+                    result = subprocess.run(
+                        ["python3", str(SCRIPT), "--allow-missing-signatures", str(package)],
+                        cwd=REPO_ROOT,
+                        text=True,
+                        capture_output=True,
+                    )
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("must be a normalized relative path", result.stderr)
 
     def test_release_path_name_mismatch_fails(self) -> None:
         with tempfile.TemporaryDirectory(prefix="registry-validate-") as tmp:

--- a/tests/test_registry_validate.py
+++ b/tests/test_registry_validate.py
@@ -158,6 +158,7 @@ class RegistryValidateTests(unittest.TestCase):
             )
 
         self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("Validated 2 manifest(s)", result.stdout)
 
     def test_integration_sources_reject_unsafe_paths(self) -> None:
         invalid_paths = [


### PR DESCRIPTION
## Summary
- Add typed integration smoke metadata for Syncthing service platform sources.
- Update registry validator path rules for typed integration source safety.
- Document typed Docker, PATH, and service integration metadata in the registry README.

## Verification
- python3 -m unittest discover -s registry/tests
- cargo test -p crosspack-registry integration_smoke_registry_packages_parse_typed_integrations -- --test-threads=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced typed host integrations with platform-specific service configuration (Linux systemd user, macOS launch agent, Windows service).
  * Services now declare explicit platform-specific path mappings instead of a generic source/enable pair.

* **Documentation**
  * Added spec describing supported integration kinds, required fields, and safe relative-path constraints.

* **Tests**
  * Added tests for service platform-source validation and enforcement of normalized relative-path rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->