### PR TITLE
feat(automation): mature upstream release bot

### DIFF
--- a/.github/workflows/upstream-release-bot.yml
+++ b/.github/workflows/upstream-release-bot.yml
@@ -20,8 +20,8 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: upstream-release-bot
-  cancel-in-progress: false
+  group: upstream-release-bot-upstream-release-rolling
+  cancel-in-progress: true
 
 jobs:
   update-registry-metadata:
@@ -77,7 +77,7 @@ jobs:
           PACKAGE_INPUT: ${{ inputs.package }}
         run: |
           set -euo pipefail
-          args=(--create-prs)
+          args=(--create-prs --branch-name upstream-release/rolling)
           if [ -n "$PACKAGE_INPUT" ]; then
             args+=(--package "$PACKAGE_INPUT")
           fi

--- a/scripts/registry-update-runbook.md
+++ b/scripts/registry-update-runbook.md
@@ -72,5 +72,7 @@ Recovery commands:
 python3 scripts/upstream-release-bot.py --dry-run --package <package>
 python3 scripts/registry-validate-source.py packages/<package>.toml
 python3 scripts/registry-validate.py --allow-missing-signatures packages/<package>.toml releases/<package>/<version>.toml
-git push --force-with-lease origin upstream-release/rolling
+git fetch origin main
+git switch -C upstream-release/rolling origin/main
+git push --force-with-lease -u origin HEAD:upstream-release/rolling
 ```

--- a/scripts/registry-update-runbook.md
+++ b/scripts/registry-update-runbook.md
@@ -16,6 +16,8 @@ Use this runbook when reviewing or updating Crosspack Registry package and relea
 
 ## Validation commands
 
+Run these commands from the `registry/` submodule root.
+
 ```bash
 python3 scripts/registry-validate-source.py packages/*.toml
 REGISTRY_PREFLIGHT_ALL=1 REGISTRY_PREFLIGHT_SKIP_SMOKE=1 ./scripts/registry-preflight.sh
@@ -32,3 +34,43 @@ python3 -m unittest \
 2. Add or regenerate `releases/<package>/<version>.toml` for concrete version metadata.
 3. Run the validation commands above.
 4. Open a PR summarizing package/release coverage changes and the validation commands you ran.
+
+## Rolling Upstream Release Bot
+
+The scheduled upstream release bot maintains one rolling PR from `upstream-release/rolling`. Each write run starts from current `main`, regenerates valid package updates, writes `state/upstream-release-bot.json`, force-updates only that bot-owned branch with `--force-with-lease`, and enables automerge. Dry runs use the same discovery path without writing metadata or opening PRs.
+
+Bot state is runtime-normalized to schema v2. Checked-in schema v1 state is migrated on read:
+
+- `schema_version`: currently `2` after runtime migration.
+- `sources`: source-level cache/audit state keyed by strategy and upstream identity, such as `github_releases:owner/repo`.
+- `packages`: package-level audit state, including source identity/kind, latest seen version, last successful generated version, `last_checked_at`, transient failure fields, and optional `backoff_until`.
+- `quarantine`: package-level records keyed by package name with `reason_code`, `detail`, `first_seen_at`, `last_seen_at`, `attempted_version`, and optional `last_good_version`.
+
+Malformed generated package updates are recorded under `quarantine` and omitted from generated metadata until a later run regenerates valid metadata and package validation passes. Quarantine is package-scoped; unrelated packages continue in the same run. Rate-limited or transient upstream failures update the affected package's `backoff_until` and skip only that package/source until the timestamp expires.
+
+Bot output includes stable summary accounting for automation consumers:
+
+```text
+registry_update package=<name> status=quarantined reason=metadata-malformed attempted=<version>
+registry_update package=<name> status=skipped reason=<rate-limited|upstream-error|backoff-active> reset_at=<iso8601>
+registry_update_summary updated=<n> up_to_date=<n> quarantined=<n> transient_failed=<n> skipped=<n>
+```
+
+Crosspack clients may skip package-level poison during broad package discovery and print additive warnings such as:
+
+```text
+warning: registry_package_skipped package="<name>" reason="package-metadata-invalid" source="<source>" detail="<detail>"
+```
+
+Source-level trust still fails closed. Missing or invalid `registry.pub`, configured fingerprint mismatches, missing ready snapshots, and missing or invalid metadata signatures are fatal for the source.
+
+Bot PR bodies summarize updated packages, generated package/release counts, state-only changes, quarantine additions/updates/clears, backoff packages, and validation commands. Bot PRs may contain unsigned `packages/*.toml` and `releases/*/*.toml` files; the `sign-manifests-on-merge` workflow signs changed sidecars after merge.
+
+Recovery commands:
+
+```bash
+python3 scripts/upstream-release-bot.py --dry-run --package <package>
+python3 scripts/registry-validate-source.py packages/<package>.toml
+python3 scripts/registry-validate.py --allow-missing-signatures packages/<package>.toml releases/<package>/<version>.toml
+git push --force-with-lease origin upstream-release/rolling
+```

--- a/scripts/upstream-release-bot.py
+++ b/scripts/upstream-release-bot.py
@@ -988,6 +988,7 @@ def _reconcile_empty_rolling_pr(
 ) -> None:
     if not _remote_branch_exists(repo_root=repo_root, branch_name=branch_name):
         return
+    _run(["git", "fetch", "origin", base_branch], cwd=repo_root)
     _run(
         ["git", "fetch", "origin", f"+refs/heads/{branch_name}:refs/remotes/origin/{branch_name}"],
         cwd=repo_root,

--- a/scripts/upstream-release-bot.py
+++ b/scripts/upstream-release-bot.py
@@ -2,10 +2,12 @@
 from __future__ import annotations
 
 import argparse
+import errno
 import http.client
 import importlib.util
 import json
 import re
+import socket
 import subprocess
 import sys
 import time
@@ -432,8 +434,18 @@ def _is_skippable_release_fetch_error(
     return "rate limit" in body or "secondary limit" in body
 
 
-def _is_transient_url_error(_error: urllib.error.URLError) -> bool:
-    return True
+def _is_transient_url_error(error: urllib.error.URLError) -> bool:
+    reason = getattr(error, "reason", None)
+    if isinstance(reason, TimeoutError | socket.timeout):
+        return True
+    if isinstance(reason, str) and "timed out" in reason.lower():
+        return True
+    reason_errno = getattr(reason, "errno", None)
+    return reason_errno in {
+        errno.EAGAIN,
+        errno.ECONNRESET,
+        errno.ETIMEDOUT,
+    }
 
 
 def fetch_json_index_releases(release_strategy: dict) -> list[dict]:
@@ -862,7 +874,6 @@ def _open_or_update_pr(
     _restore_path_snapshot(repo_root, path_snapshot)
     if staged_paths:
         _run(["git", "add", *(str(path) for path in staged_paths)], cwd=repo_root)
-    validate_generated_paths(repo_root=repo_root, staged_paths=staged_paths)
     staged = _run(["git", "diff", "--cached", "--name-only"], cwd=repo_root)
     if not staged.stdout.strip():
         number = _open_pr_number_for_branch(repo_root=repo_root, branch_name=branch_name)
@@ -870,6 +881,7 @@ def _open_or_update_pr(
             _enable_pr_automerge(repo_root=repo_root, pr_ref=str(number))
             print(f"PR already open for {branch_name}; enabled automerge")
         return
+    validate_generated_paths(repo_root=repo_root, staged_paths=staged_paths)
 
     _run(["git", "commit", "-m", title], cwd=repo_root)
     _run(["git", "push", "-u", "origin", branch_name], cwd=repo_root)
@@ -914,7 +926,6 @@ def _open_or_update_rolling_pr(
     _restore_path_snapshot(repo_root, path_snapshot)
     if staged_paths:
         _run(["git", "add", *(str(path) for path in staged_paths)], cwd=repo_root)
-    validate_generated_paths(repo_root=repo_root, staged_paths=staged_paths)
     staged = _run(["git", "diff", "--cached", "--name-only"], cwd=repo_root)
     if not staged.stdout.strip():
         number = _open_pr_number_for_branch(repo_root=repo_root, branch_name=branch_name)
@@ -922,6 +933,7 @@ def _open_or_update_rolling_pr(
             _enable_pr_automerge(repo_root=repo_root, pr_ref=str(number))
             print(f"PR already open for {branch_name}; enabled automerge")
         return
+    validate_generated_paths(repo_root=repo_root, staged_paths=staged_paths)
     _run(["git", "commit", "-m", title], cwd=repo_root)
     push_cmd = ["git", "push", "--force-with-lease", "-u", "origin", branch_name]
     if _remote_branch_exists(repo_root=repo_root, branch_name=branch_name):
@@ -969,6 +981,43 @@ def _open_or_update_rolling_pr(
         cwd=repo_root,
     )
     _enable_pr_automerge(repo_root=repo_root, pr_ref=branch_name)
+
+
+def _reconcile_empty_rolling_pr(
+    *, repo_root: Path, base_branch: str, branch_name: str
+) -> None:
+    if not _remote_branch_exists(repo_root=repo_root, branch_name=branch_name):
+        return
+    _run(
+        ["git", "fetch", "origin", f"+refs/heads/{branch_name}:refs/remotes/origin/{branch_name}"],
+        cwd=repo_root,
+    )
+    expected = _run(
+        ["git", "rev-parse", f"refs/remotes/origin/{branch_name}"], cwd=repo_root
+    ).stdout.strip()
+    _run(
+        [
+            "git",
+            "push",
+            f"--force-with-lease=refs/heads/{branch_name}:{expected}",
+            "origin",
+            f"origin/{base_branch}:refs/heads/{branch_name}",
+        ],
+        cwd=repo_root,
+    )
+    number = _open_pr_number_for_branch(repo_root=repo_root, branch_name=branch_name)
+    if number is not None:
+        _run(
+            [
+                "gh",
+                "pr",
+                "close",
+                str(number),
+                "--comment",
+                "Closing stale rolling release PR: no generated changes remain.",
+            ],
+            cwd=repo_root,
+        )
 
 
 def render_pr_body(
@@ -1236,6 +1285,12 @@ def main(argv: list[str]) -> int:
             up_to_date_packages += 1
 
     if not planned and not state_changed:
+        if args.create_prs:
+            _reconcile_empty_rolling_pr(
+                repo_root=repo_root,
+                base_branch=args.base_branch,
+                branch_name=args.branch_name,
+            )
         print(
             "No new releases detected; "
             f"skipped {skipped_fetches} release fetch(es)"
@@ -1347,7 +1402,7 @@ def main(argv: list[str]) -> int:
             )
         # Keep package validation failures isolated: restore staged writes,
         # record the error, quarantine this package, and continue others.
-        except Exception as exc:
+        except (subprocess.CalledProcessError, RuntimeError) as exc:
             if package_path in staged_paths and written_packages > 0:
                 written_packages -= 1
             for generated_path in staged_paths:

--- a/scripts/upstream-release-bot.py
+++ b/scripts/upstream-release-bot.py
@@ -1154,7 +1154,6 @@ def main(argv: list[str]) -> int:
                         if key in package_state:
                             package_state.pop(key, None)
                             state_changed = True
-                    state_changed = True
                     continue
                 releases = fetch_result.releases
                 version_strategy = normalized.get("version")
@@ -1346,6 +1345,8 @@ def main(argv: list[str]) -> int:
                 package=update.package,
                 staged_paths=staged_paths,
             )
+        # Keep package validation failures isolated: restore staged writes,
+        # record the error, quarantine this package, and continue others.
         except Exception as exc:
             if package_path in staged_paths and written_packages > 0:
                 written_packages -= 1

--- a/scripts/upstream-release-bot.py
+++ b/scripts/upstream-release-bot.py
@@ -23,7 +23,7 @@ except ModuleNotFoundError:
 
 
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
-STATE_SCHEMA_VERSION = 1
+STATE_SCHEMA_VERSION = 2
 
 
 class PlannedUpdate:
@@ -120,7 +120,36 @@ def _load_generator_module(repo_root: Path):
 
 
 def empty_bot_state() -> dict[str, Any]:
-    return {"schema_version": STATE_SCHEMA_VERSION, "sources": {}}
+    return {"schema_version": STATE_SCHEMA_VERSION, "sources": {}, "packages": {}, "quarantine": {}}
+
+
+def _object_map(value: object) -> dict[str, dict[str, Any]]:
+    if not isinstance(value, dict):
+        return {}
+    return {
+        key: entry
+        for key, entry in value.items()
+        if isinstance(key, str) and isinstance(entry, dict)
+    }
+
+
+def _normalize_bot_state(data: dict[str, Any]) -> dict[str, Any] | None:
+    schema_version = data.get("schema_version")
+    if schema_version == 1:
+        return {
+            "schema_version": STATE_SCHEMA_VERSION,
+            "sources": _object_map(data.get("sources")),
+            "packages": {},
+            "quarantine": {},
+        }
+    if schema_version != STATE_SCHEMA_VERSION:
+        return None
+    return {
+        "schema_version": STATE_SCHEMA_VERSION,
+        "sources": _object_map(data.get("sources")),
+        "packages": _object_map(data.get("packages")),
+        "quarantine": _object_map(data.get("quarantine")),
+    }
 
 
 def load_bot_state(path: Path) -> dict[str, Any]:
@@ -131,40 +160,169 @@ def load_bot_state(path: Path) -> dict[str, Any]:
     except (OSError, json.JSONDecodeError) as exc:
         print(f"Ignoring invalid release bot state at {path}: {exc}", file=sys.stderr)
         return empty_bot_state()
-    if not isinstance(data, dict) or data.get("schema_version") != STATE_SCHEMA_VERSION:
+    if not isinstance(data, dict):
+        print(f"Ignoring invalid release bot state at {path}: root must be an object", file=sys.stderr)
+        return empty_bot_state()
+    normalized = _normalize_bot_state(data)
+    if normalized is None:
         print(f"Ignoring unsupported release bot state at {path}", file=sys.stderr)
         return empty_bot_state()
-    sources = data.get("sources")
-    if not isinstance(sources, dict):
-        print(
-            f"Ignoring invalid release bot state at {path}: sources must be an object",
-            file=sys.stderr,
-        )
-        return empty_bot_state()
-    normalized_sources = {
-        key: value
-        for key, value in sources.items()
-        if isinstance(key, str) and isinstance(value, dict)
-    }
-    return {"schema_version": STATE_SCHEMA_VERSION, "sources": normalized_sources}
+    return normalized
 
 
 def write_bot_state(path: Path, state: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    sources = state.get("sources")
-    if not isinstance(sources, dict):
-        sources = {}
     normalized = {
+        "packages": dict(sorted(_object_map(state.get("packages")).items())),
+        "quarantine": dict(sorted(_object_map(state.get("quarantine")).items())),
         "schema_version": STATE_SCHEMA_VERSION,
-        "sources": dict(sorted(sources.items())),
+        "sources": dict(sorted(_object_map(state.get("sources")).items())),
     }
     path.write_text(
         json.dumps(normalized, indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )
 
 
+def bot_state_needs_persist(path: Path, state: dict[str, Any]) -> bool:
+    if not path.exists():
+        return False
+    try:
+        current = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return True
+    expected = {
+        "packages": dict(sorted(_object_map(state.get("packages")).items())),
+        "quarantine": dict(sorted(_object_map(state.get("quarantine")).items())),
+        "schema_version": STATE_SCHEMA_VERSION,
+        "sources": dict(sorted(_object_map(state.get("sources")).items())),
+    }
+    return current != expected
+
+
 def utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def iso_from_epoch(epoch: int) -> str:
+    return datetime.fromtimestamp(epoch, timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def iso_after_seconds(now_iso: str, seconds: int) -> str:
+    current = datetime.fromisoformat(now_iso.replace("Z", "+00:00"))
+    return iso_from_epoch(int(current.timestamp()) + seconds)
+
+
+def package_backoff_active(package_state: dict[str, Any], *, now_iso: str | None = None) -> bool:
+    backoff_until = package_state.get("backoff_until")
+    if not isinstance(backoff_until, str) or not backoff_until:
+        return False
+    current = now_iso or utc_now_iso()
+    return backoff_until > current
+
+
+def backoff_from_http_error(error: urllib.error.HTTPError, *, now_epoch: int | None = None) -> dict[str, Any]:
+    reset = error.headers.get("x-ratelimit-reset") if error.headers else None
+    if isinstance(reset, str) and reset.isdigit():
+        reset_epoch = int(reset)
+    else:
+        base = int(time.time() if now_epoch is None else now_epoch)
+        reset_epoch = base + 3600
+    return {
+        "reason_code": "rate-limited",
+        "detail": _format_fetch_error(error),
+        "backoff_until": iso_from_epoch(reset_epoch),
+        "last_failure_reason": "rate-limited",
+        "last_failure_reset_at": iso_from_epoch(reset_epoch),
+        "last_failed_at": utc_now_iso(),
+    }
+
+
+def backoff_from_transient_fetch_error(
+    error: urllib.error.HTTPError | urllib.error.URLError,
+) -> dict[str, Any]:
+    now = utc_now_iso()
+    if isinstance(error, urllib.error.HTTPError) and error.code == 429:
+        reset = error.headers.get("x-ratelimit-reset") if error.headers else None
+        if isinstance(reset, str) and reset.isdigit():
+            backoff_until = iso_from_epoch(int(reset))
+        else:
+            backoff_until = iso_after_seconds(now, 3600)
+        return {
+            "reason_code": "rate-limited",
+            "detail": _format_fetch_error(error),
+            "backoff_until": backoff_until,
+            "last_failure_reason": "rate-limited",
+            "last_failure_reset_at": backoff_until,
+            "last_failed_at": now,
+        }
+
+    backoff_until = iso_after_seconds(now, 3600)
+    return {
+        "reason_code": "upstream-error",
+        "detail": _format_fetch_error(error),
+        "backoff_until": backoff_until,
+        "last_failure_reason": "upstream-error",
+        "last_failure_reset_at": backoff_until,
+        "last_failed_at": now,
+    }
+
+
+def source_identity_for_release(release_kind: object, release_strategy: dict) -> str | None:
+    if release_kind == "github_releases":
+        repo = release_strategy.get("repo")
+        return github_release_state_key(repo) if isinstance(repo, str) else None
+    url = release_strategy.get("url")
+    if isinstance(release_kind, str) and isinstance(url, str):
+        return f"{release_kind}:{url}"
+    return release_kind if isinstance(release_kind, str) else None
+
+
+def apply_package_source_audit(
+    package_state: dict[str, Any], *, source_identity: str | None, source_kind: object
+) -> None:
+    if source_identity is not None:
+        package_state["source_identity"] = source_identity
+    if isinstance(source_kind, str):
+        package_state["source_kind"] = source_kind
+
+
+def quarantine_package(
+    state: dict[str, Any],
+    *,
+    package: str,
+    reason_code: str,
+    detail: str,
+    attempted_version: str,
+    last_good_version: str | None,
+    now_iso: str | None = None,
+) -> bool:
+    quarantine = state.setdefault("quarantine", {})
+    if not isinstance(quarantine, dict):
+        quarantine = {}
+        state["quarantine"] = quarantine
+    now_value = now_iso or utc_now_iso()
+    previous = quarantine.get(package)
+    first_seen = previous.get("first_seen_at") if isinstance(previous, dict) else None
+    next_entry = {
+        "reason_code": reason_code,
+        "detail": detail,
+        "first_seen_at": first_seen if isinstance(first_seen, str) else now_value,
+        "last_seen_at": now_value,
+        "attempted_version": attempted_version,
+    }
+    if last_good_version is not None:
+        next_entry["last_good_version"] = last_good_version
+    changed = previous != next_entry
+    quarantine[package] = next_entry
+    return changed
+
+
+def clear_quarantine(state: dict[str, Any], *, package: str) -> bool:
+    quarantine = state.setdefault("quarantine", {})
+    if not isinstance(quarantine, dict):
+        state["quarantine"] = {}
+        return False
+    return quarantine.pop(package, None) is not None
 
 
 def github_release_state_key(repo: str) -> str:
@@ -260,18 +418,22 @@ def _http_error_body(error: urllib.error.HTTPError) -> str:
 def _is_skippable_release_fetch_error(
     *, error: urllib.error.HTTPError, release_kind: object
 ) -> bool:
+    if error.code == 429 or 500 <= error.code <= 599:
+        return True
     if error.code != 403:
         return False
-    if release_kind == "github_releases":
-        return True
     reason = str(error.reason).lower()
-    if "rate limit" in reason:
+    if "rate limit" in reason or "secondary limit" in reason:
         return True
     remaining = error.headers.get("x-ratelimit-remaining") if error.headers else None
     if remaining == "0":
         return True
     body = _http_error_body(error).lower()
-    return "rate limit" in body
+    return "rate limit" in body or "secondary limit" in body
+
+
+def _is_transient_url_error(_error: urllib.error.URLError) -> bool:
+    return True
 
 
 def fetch_json_index_releases(release_strategy: dict) -> list[dict]:
@@ -562,6 +724,19 @@ def validate_generated_paths(*, repo_root: Path, staged_paths: list[Path]) -> No
         )
 
 
+def validate_package_generated_paths(*, repo_root: Path, package: str, staged_paths: list[Path]) -> None:
+    package_paths = [path for path in staged_paths if path == Path("packages") / f"{package}.toml"]
+    release_paths = [
+        path
+        for path in staged_paths
+        if len(path.parts) == 3
+        and path.parts[0] == "releases"
+        and path.parts[1] == package
+        and path.suffix == ".toml"
+    ]
+    validate_generated_paths(repo_root=repo_root, staged_paths=[*package_paths, *release_paths])
+
+
 def _enable_pr_automerge(*, repo_root: Path, pr_ref: str) -> None:
     _run(["gh", "pr", "merge", pr_ref, "--auto", "--squash"], cwd=repo_root)
 
@@ -588,6 +763,17 @@ def _open_pr_number_for_branch(*, repo_root: Path, branch_name: str) -> int | No
     if not isinstance(number, int):
         raise RuntimeError(f"Unexpected PR lookup response for {branch_name}")
     return number
+
+
+def _remote_branch_exists(*, repo_root: Path, branch_name: str) -> bool:
+    result = subprocess.run(
+        ["git", "ls-remote", "--exit-code", "origin", branch_name],
+        cwd=repo_root,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    return result.returncode == 0
 
 
 def _stash_paths_for_branch_switch(*, repo_root: Path, paths: list[Path]) -> str | None:
@@ -713,6 +899,117 @@ def _open_or_update_pr(
     _enable_pr_automerge(repo_root=repo_root, pr_ref=branch_name)
 
 
+def _open_or_update_rolling_pr(
+    *,
+    repo_root: Path,
+    staged_paths: list[Path],
+    base_branch: str,
+    branch_name: str,
+    title: str,
+    body: str,
+) -> None:
+    path_snapshot = _snapshot_paths(repo_root, staged_paths)
+    _run(["git", "fetch", "origin", base_branch], cwd=repo_root)
+    _run(["git", "switch", "-C", branch_name, f"origin/{base_branch}"], cwd=repo_root)
+    _restore_path_snapshot(repo_root, path_snapshot)
+    if staged_paths:
+        _run(["git", "add", *(str(path) for path in staged_paths)], cwd=repo_root)
+    validate_generated_paths(repo_root=repo_root, staged_paths=staged_paths)
+    staged = _run(["git", "diff", "--cached", "--name-only"], cwd=repo_root)
+    if not staged.stdout.strip():
+        number = _open_pr_number_for_branch(repo_root=repo_root, branch_name=branch_name)
+        if number is not None:
+            _enable_pr_automerge(repo_root=repo_root, pr_ref=str(number))
+            print(f"PR already open for {branch_name}; enabled automerge")
+        return
+    _run(["git", "commit", "-m", title], cwd=repo_root)
+    push_cmd = ["git", "push", "--force-with-lease", "-u", "origin", branch_name]
+    if _remote_branch_exists(repo_root=repo_root, branch_name=branch_name):
+        _run(
+            [
+                "git",
+                "fetch",
+                "origin",
+                f"+refs/heads/{branch_name}:refs/remotes/origin/{branch_name}",
+            ],
+            cwd=repo_root,
+        )
+        expected = _run(
+            ["git", "rev-parse", f"refs/remotes/origin/{branch_name}"], cwd=repo_root
+        ).stdout.strip()
+        push_cmd = [
+            "git",
+            "push",
+            f"--force-with-lease=refs/heads/{branch_name}:{expected}",
+            "-u",
+            "origin",
+            branch_name,
+        ]
+    _run(push_cmd, cwd=repo_root)
+    number = _open_pr_number_for_branch(repo_root=repo_root, branch_name=branch_name)
+    if number is not None:
+        _run(["gh", "pr", "edit", str(number), "--title", title, "--body", body], cwd=repo_root)
+        _enable_pr_automerge(repo_root=repo_root, pr_ref=str(number))
+        print(f"Updated PR #{number} for {branch_name}; enabled automerge")
+        return
+    _run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--base",
+            base_branch,
+            "--head",
+            branch_name,
+            "--title",
+            title,
+            "--body",
+            body,
+        ],
+        cwd=repo_root,
+    )
+    _enable_pr_automerge(repo_root=repo_root, pr_ref=branch_name)
+
+
+def render_pr_body(
+    *,
+    updated_packages: list[str],
+    quarantine_added: list[str],
+    quarantine_updated: list[str],
+    quarantine_cleared: list[str],
+    backoff_packages: list[str],
+    state_changed: bool,
+    created_releases: int,
+    written_packages: int,
+    quarantined_count: int,
+    transient_failures: int,
+    skipped_fetches: int,
+) -> str:
+    updated = ", ".join(sorted(updated_packages)) if updated_packages else "none"
+    added = ", ".join(sorted(set(quarantine_added))) if quarantine_added else "none"
+    quarantine_updated_value = ", ".join(sorted(set(quarantine_updated))) if quarantine_updated else "none"
+    cleared = ", ".join(sorted(set(quarantine_cleared))) if quarantine_cleared else "none"
+    backoff = ", ".join(sorted(set(backoff_packages))) if backoff_packages else "none"
+    return (
+        "## Summary\n"
+        f"- updated packages: {updated}\n"
+        f"- quarantined packages: {quarantined_count}\n"
+        f"- release manifests written: {created_releases}\n"
+        f"- package templates updated: {written_packages}\n"
+        f"- transient fetch failures: {transient_failures}\n"
+        f"- release fetches skipped: {skipped_fetches}\n"
+        "\n## Audit\n"
+        f"- state changed: {'yes' if state_changed else 'no'}\n"
+        f"- quarantine added: {added}\n"
+        f"- quarantine updated: {quarantine_updated_value}\n"
+        f"- quarantine cleared: {cleared}\n"
+        f"- backoff packages: {backoff}\n"
+        "\n## Validation\n"
+        "- registry-validate-source.py for changed package templates\n"
+        "- registry-validate.py --allow-missing-signatures for changed metadata\n"
+    )
+
+
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(
         description="Generate/update manifests from upstream releases"
@@ -739,7 +1036,8 @@ def main(argv: list[str]) -> int:
         help="Commit changes and open PRs with gh",
     )
     parser.add_argument("--base-branch", default="main")
-    parser.add_argument("--branch-prefix", default="upstream-release")
+    parser.add_argument("--branch-name", default="upstream-release/rolling")
+    parser.add_argument("--branch-prefix", default=None, help=argparse.SUPPRESS)
     parser.add_argument(
         "--state-path",
         type=Path,
@@ -749,6 +1047,10 @@ def main(argv: list[str]) -> int:
     args = parser.parse_args(argv)
 
     repo_root = Path.cwd()
+    if args.create_prs:
+        _run(["git", "fetch", "origin", args.base_branch], cwd=repo_root)
+        _run(["git", "switch", "-C", args.branch_name, f"origin/{args.base_branch}"], cwd=repo_root)
+
     generator = _load_generator_module(repo_root)
 
     package_filter = set(args.package or [])
@@ -766,17 +1068,52 @@ def main(argv: list[str]) -> int:
     if not isinstance(state_sources, dict):
         state_sources = {}
         bot_state["sources"] = state_sources
-    state_changed = False
+    state_packages = bot_state.setdefault("packages", {})
+    if not isinstance(state_packages, dict):
+        state_packages = {}
+        bot_state["packages"] = state_packages
+    state_changed = bot_state_needs_persist(args.state_path, bot_state)
     planned: list[PlannedUpdate] = []
     skipped_fetches = 0
+    transient_fetch_failures = 0
+    up_to_date_packages = 0
+    all_staged_paths: list[Path] = []
+    updated_packages: list[str] = []
+    quarantine_added: list[str] = []
+    quarantine_updated: list[str] = []
+    quarantine_cleared: list[str] = []
+    backoff_packages: list[str] = []
     for config_path in config_paths:
         config = load_config(config_path)
+        package_name = str(config.get("name") or config_path.stem)
+        package_state = state_packages.setdefault(package_name, {})
+        if not isinstance(package_state, dict):
+            package_state = {}
+            state_packages[package_name] = package_state
+        if package_backoff_active(package_state):
+            skipped_fetches += 1
+            backoff_packages.append(
+                f"{package_name}:backoff-active:{package_state.get('backoff_until')}"
+            )
+            print(
+                f"registry_update package={package_name} status=skipped reason=backoff-active "
+                f"reset_at={package_state.get('backoff_until')}",
+                file=sys.stderr,
+            )
+            continue
         source = config.get("source")
         if not isinstance(source, dict):
             raise RuntimeError(f"Missing source table in {config_path}")
         normalized = normalize_source(source)
         release_strategy = normalized["release"]
         release_kind = release_strategy.get("kind")
+        source_identity = source_identity_for_release(release_kind, release_strategy)
+        previous_package_state = dict(package_state)
+        apply_package_source_audit(
+            package_state, source_identity=source_identity, source_kind=release_kind
+        )
+        if package_state != previous_package_state:
+            state_changed = True
         try:
             if release_kind == "json_index":
                 releases = fetch_json_index_releases(release_strategy)
@@ -794,12 +1131,40 @@ def main(argv: list[str]) -> int:
                     repo, token=github_token, state_entry=state_entry
                 )
                 if fetch_result.not_modified:
+                    up_to_date_packages += 1
+                    checked_at = utc_now_iso()
+                    package_state["last_checked_at"] = checked_at
+                    next_entry = dict(state_entry or {})
+                    if source_identity is not None:
+                        next_entry["source_identity"] = source_identity
+                    if isinstance(release_kind, str):
+                        next_entry["source_kind"] = release_kind
+                    next_entry["last_checked_at"] = checked_at
+                    if next_entry != state_sources.get(state_key):
+                        state_sources[state_key] = next_entry
+                        state_changed = True
+                    for key in (
+                        "backoff_until",
+                        "reason_code",
+                        "detail",
+                        "last_failed_at",
+                        "last_failure_reason",
+                        "last_failure_reset_at",
+                    ):
+                        if key in package_state:
+                            package_state.pop(key, None)
+                            state_changed = True
+                    state_changed = True
                     continue
                 releases = fetch_result.releases
                 version_strategy = normalized.get("version")
                 if not isinstance(version_strategy, dict):
                     version_strategy = {"kind": "github_tag"}
                 next_entry = dict(state_entry or {})
+                if source_identity is not None:
+                    next_entry["source_identity"] = source_identity
+                if isinstance(release_kind, str):
+                    next_entry["source_kind"] = release_kind
                 if fetch_result.etag:
                     next_entry["etag"] = fetch_result.etag
                 if fetch_result.last_modified:
@@ -810,35 +1175,76 @@ def main(argv: list[str]) -> int:
                 )
                 if latest_version is not None:
                     next_entry["latest_version"] = latest_version
+                    next_entry["latest_seen_version"] = latest_version
+                    package_state["latest_seen_version"] = latest_version
+                package_state["last_checked_at"] = next_entry["last_checked_at"]
                 if next_entry != state_sources.get(state_key):
                     state_sources[state_key] = next_entry
                     state_changed = True
             else:
                 raise RuntimeError(f"Unsupported source.release.kind in {config_path}")
-        except urllib.error.HTTPError as error:
-            if not _is_skippable_release_fetch_error(
-                error=error, release_kind=release_kind
+            for key in (
+                "backoff_until",
+                "reason_code",
+                "detail",
+                "last_failed_at",
+                "last_failure_reason",
+                "last_failure_reset_at",
             ):
+                if key in package_state:
+                    package_state.pop(key, None)
+                    state_changed = True
+        except (urllib.error.HTTPError, urllib.error.URLError) as error:
+            if isinstance(error, urllib.error.HTTPError):
+                if not _is_skippable_release_fetch_error(
+                    error=error, release_kind=release_kind
+                ):
+                    raise
+            elif not _is_transient_url_error(error):
                 raise
+            if isinstance(error, urllib.error.HTTPError) and error.code == 403:
+                package_state.update(backoff_from_http_error(error))
+            else:
+                package_state.update(backoff_from_transient_fetch_error(error))
+            apply_package_source_audit(
+                package_state, source_identity=source_identity, source_kind=release_kind
+            )
+            state_changed = True
             skipped_fetches += 1
+            transient_fetch_failures += 1
+            backoff_packages.append(
+                f"{package_name}:{package_state.get('reason_code')}:{package_state.get('backoff_until')}"
+            )
             print(
                 f"Skipping {config_path.stem}: failed to fetch upstream releases "
                 f"({_format_fetch_error(error)})",
                 file=sys.stderr,
             )
-            continue
-        planned.extend(
-            plan_updates_for_config(
-                config_path=config_path,
-                releases_root=args.releases_root,
-                releases=releases,
+            print(
+                f"registry_update package={package_name} status=skipped "
+                f"reason={package_state.get('reason_code')} reset_at={package_state.get('backoff_until')}",
+                file=sys.stderr,
             )
+            continue
+        planned_for_config = plan_updates_for_config(
+            config_path=config_path,
+            releases_root=args.releases_root,
+            releases=releases,
         )
+        if planned_for_config:
+            planned.extend(planned_for_config)
+        else:
+            up_to_date_packages += 1
 
-    if not planned:
+    if not planned and not state_changed:
         print(
             "No new releases detected; "
             f"skipped {skipped_fetches} release fetch(es)"
+        )
+        print(
+            f"registry_update_summary updated=0 up_to_date={up_to_date_packages} "
+            "quarantined=0 transient_failed=0 "
+            f"skipped={skipped_fetches}"
         )
         return 0
 
@@ -872,10 +1278,36 @@ def main(argv: list[str]) -> int:
                 shasums_by_name=shasums_by_name,
             )
         except generator.GenerateError as exc:
+            package_state = state_packages.setdefault(update.package, {})
+            if not isinstance(package_state, dict):
+                package_state = {}
+                state_packages[update.package] = package_state
+            last_good_version = package_state.get("last_successful_version")
+            if not isinstance(last_good_version, str):
+                last_good_version = None
+            existing_quarantine = update.package in _object_map(bot_state.get("quarantine"))
+            if quarantine_package(
+                bot_state,
+                package=update.package,
+                reason_code="metadata-malformed",
+                detail=str(exc),
+                attempted_version=update.version,
+                last_good_version=last_good_version,
+            ):
+                state_changed = True
+                if existing_quarantine:
+                    quarantine_updated.append(update.package)
+                else:
+                    quarantine_added.append(update.package)
             skipped_updates += 1
             print(
                 "Skipping "
                 f"{update.package} {update.version}: incomplete upstream release ({exc})",
+                file=sys.stderr,
+            )
+            print(
+                f"registry_update package={update.package} status=quarantined "
+                f"reason=metadata-malformed attempted={update.version}",
                 file=sys.stderr,
             )
             continue
@@ -902,23 +1334,102 @@ def main(argv: list[str]) -> int:
         release_path.parent.mkdir(parents=True, exist_ok=True)
         release_path.write_text(release_text, encoding="utf-8")
         print(f"Generated {release_path}")
-        created_releases += 1
         staged_paths.append(release_path)
 
-        if state_changed:
-            write_bot_state(args.state_path, bot_state)
-            if args.state_path not in staged_paths:
-                staged_paths.append(args.state_path)
-
-        if args.create_prs:
-            _open_or_update_pr(
+        package_state = state_packages.setdefault(update.package, {})
+        if not isinstance(package_state, dict):
+            package_state = {}
+            state_packages[update.package] = package_state
+        try:
+            validate_package_generated_paths(
                 repo_root=repo_root,
-                staged_paths=staged_paths,
                 package=update.package,
-                version=update.version,
-                base_branch=args.base_branch,
-                branch_prefix=args.branch_prefix,
+                staged_paths=staged_paths,
             )
+        except Exception as exc:
+            if package_path in staged_paths and written_packages > 0:
+                written_packages -= 1
+            for generated_path in staged_paths:
+                full_path = repo_root / generated_path
+                if generated_path == package_path and current_package_text is not None:
+                    full_path.write_text(current_package_text, encoding="utf-8")
+                elif full_path.exists():
+                    full_path.unlink()
+            last_good_version = package_state.get("last_successful_version")
+            if not isinstance(last_good_version, str):
+                last_good_version = None
+            existing_quarantine = update.package in _object_map(bot_state.get("quarantine"))
+            if quarantine_package(
+                bot_state,
+                package=update.package,
+                reason_code="metadata-malformed",
+                detail=str(exc),
+                attempted_version=update.version,
+                last_good_version=last_good_version,
+            ):
+                state_changed = True
+                if existing_quarantine:
+                    quarantine_updated.append(update.package)
+                else:
+                    quarantine_added.append(update.package)
+            skipped_updates += 1
+            print(
+                "Skipping "
+                f"{update.package} {update.version}: incomplete upstream release ({exc})",
+                file=sys.stderr,
+            )
+            print(
+                f"registry_update package={update.package} status=quarantined "
+                f"reason=metadata-malformed attempted={update.version}",
+                file=sys.stderr,
+            )
+            continue
+
+        created_releases += 1
+        package_state["last_successful_version"] = update.version
+        package_state["last_generated_at"] = utc_now_iso()
+        state_changed = True
+        if clear_quarantine(bot_state, package=update.package):
+            state_changed = True
+            quarantine_cleared.append(update.package)
+        updated_packages.append(f"{update.package}@{update.version}")
+        for path in staged_paths:
+            if path not in all_staged_paths:
+                all_staged_paths.append(path)
+
+    if state_changed and not args.dry_run:
+        write_bot_state(args.state_path, bot_state)
+        if args.state_path not in all_staged_paths:
+            all_staged_paths.append(args.state_path)
+
+    if args.create_prs and all_staged_paths:
+        body = render_pr_body(
+            updated_packages=updated_packages,
+            quarantine_added=quarantine_added,
+            quarantine_updated=quarantine_updated,
+            quarantine_cleared=quarantine_cleared,
+            backoff_packages=backoff_packages,
+            state_changed=state_changed,
+            created_releases=created_releases,
+            written_packages=written_packages,
+            quarantined_count=len(set([*quarantine_added, *quarantine_updated])),
+            transient_failures=transient_fetch_failures,
+            skipped_fetches=skipped_fetches,
+        )
+        _open_or_update_rolling_pr(
+            repo_root=repo_root,
+            staged_paths=all_staged_paths,
+            base_branch=args.base_branch,
+            branch_name=args.branch_name,
+            title="chore(registry): update upstream releases",
+            body=body,
+        )
+
+    if not planned:
+        print(
+            "No new releases detected; "
+            f"skipped {skipped_fetches} release fetch(es)"
+        )
 
     print(
         "Planned "
@@ -926,6 +1437,14 @@ def main(argv: list[str]) -> int:
         f"updated {written_packages} package template(s), "
         f"skipped {skipped_updates} incomplete update(s), "
         f"skipped {skipped_fetches} release fetch(es)"
+    )
+    print(
+        "registry_update_summary "
+        f"updated={created_releases} "
+        f"up_to_date={up_to_date_packages} "
+        f"quarantined={len(set([*quarantine_added, *quarantine_updated]))} "
+        f"transient_failed={transient_fetch_failures} "
+        f"skipped={skipped_fetches}"
     )
     return 0
 

--- a/scripts/upstream-release-bot.py
+++ b/scripts/upstream-release-bot.py
@@ -1132,6 +1132,7 @@ def main(argv: list[str]) -> int:
     quarantine_updated: list[str] = []
     quarantine_cleared: list[str] = []
     backoff_packages: list[str] = []
+    pr_material_state_changed = False
     for config_path in config_paths:
         config = load_config(config_path)
         package_name = str(config.get("name") or config_path.stem)
@@ -1258,6 +1259,7 @@ def main(argv: list[str]) -> int:
                 package_state, source_identity=source_identity, source_kind=release_kind
             )
             state_changed = True
+            pr_material_state_changed = True
             skipped_fetches += 1
             transient_fetch_failures += 1
             backoff_packages.append(
@@ -1349,6 +1351,7 @@ def main(argv: list[str]) -> int:
                 last_good_version=last_good_version,
             ):
                 state_changed = True
+                pr_material_state_changed = True
                 if existing_quarantine:
                     quarantine_updated.append(update.package)
                 else:
@@ -1424,6 +1427,7 @@ def main(argv: list[str]) -> int:
                 last_good_version=last_good_version,
             ):
                 state_changed = True
+                pr_material_state_changed = True
                 if existing_quarantine:
                     quarantine_updated.append(update.package)
                 else:
@@ -1445,13 +1449,32 @@ def main(argv: list[str]) -> int:
         package_state["last_successful_version"] = update.version
         package_state["last_generated_at"] = utc_now_iso()
         state_changed = True
+        pr_material_state_changed = True
         if clear_quarantine(bot_state, package=update.package):
             state_changed = True
+            pr_material_state_changed = True
             quarantine_cleared.append(update.package)
         updated_packages.append(f"{update.package}@{update.version}")
         for path in staged_paths:
             if path not in all_staged_paths:
                 all_staged_paths.append(path)
+
+    if args.create_prs and not planned and not pr_material_state_changed:
+        _reconcile_empty_rolling_pr(
+            repo_root=repo_root,
+            base_branch=args.base_branch,
+            branch_name=args.branch_name,
+        )
+        print(
+            "No new releases detected; "
+            f"skipped {skipped_fetches} release fetch(es)"
+        )
+        print(
+            f"registry_update_summary updated=0 up_to_date={up_to_date_packages} "
+            "quarantined=0 transient_failed=0 "
+            f"skipped={skipped_fetches}"
+        )
+        return 0
 
     if state_changed and not args.dry_run:
         write_bot_state(args.state_path, bot_state)

--- a/tests/test_upstream_release_bot.py
+++ b/tests/test_upstream_release_bot.py
@@ -4,6 +4,7 @@ import importlib.util
 import io
 import json
 import os
+import socket
 import subprocess
 import tempfile
 import textwrap
@@ -874,6 +875,52 @@ class UpstreamReleaseBotTests(unittest.TestCase):
             stdout.getvalue(),
         )
 
+    def test_url_dns_fetch_failure_is_not_package_scoped(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-") as tmp:
+            tmp_path = Path(tmp)
+            packages_dir = tmp_path / "packages"
+            packages_dir.mkdir(parents=True)
+            (packages_dir / "trivy.toml").write_text(
+                textwrap.dedent(
+                    """
+                    name = "trivy"
+                    license = "Apache-2.0"
+                    homepage = "https://github.com/aquasecurity/trivy"
+
+                    [source.release]
+                    kind = "github_releases"
+                    repo = "aquasecurity/trivy"
+
+                    [source.checksum]
+                    kind = "asset_digest"
+
+                    [source.asset]
+                    kind = "release_asset_url"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            generator = load_generator_module()
+            previous_cwd = Path.cwd()
+            os.chdir(tmp_path)
+            try:
+                with (
+                    mock.patch.object(self.bot, "_load_generator_module", return_value=generator),
+                    mock.patch.object(
+                        self.bot,
+                        "fetch_github_releases",
+                        side_effect=urllib.error.URLError(
+                            socket.gaierror(socket.EAI_NONAME, "Name or service not known")
+                        ),
+                    ),
+                ):
+                    with self.assertRaises(urllib.error.URLError):
+                        self.bot.main(["--package", "trivy"])
+            finally:
+                os.chdir(previous_cwd)
+
     def test_release_fetch_non_rate_http_error_still_fails(self) -> None:
         with tempfile.TemporaryDirectory(prefix="release-bot-") as tmp:
             tmp_path = Path(tmp)
@@ -1496,6 +1543,80 @@ class UpstreamReleaseBotTests(unittest.TestCase):
                 "+refs/heads/upstream-release/rolling:refs/remotes/origin/upstream-release/rolling",
             ],
             calls[:push_index],
+        )
+
+    def test_open_or_update_rolling_pr_skips_validation_when_no_staged_changes(self) -> None:
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, *, cwd):
+            calls.append(cmd)
+            stdout = ""
+            if cmd == ["git", "diff", "--cached", "--name-only"]:
+                stdout = ""
+            if cmd[:4] == ["gh", "pr", "list", "--head"]:
+                stdout = '[{"number": 12}]'
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        with tempfile.TemporaryDirectory(prefix="release-bot-pr-") as tmp:
+            repo = Path(tmp)
+            with mock.patch.object(self.bot, "_run", side_effect=fake_run), mock.patch.object(
+                self.bot, "validate_generated_paths"
+            ) as validate_generated_paths:
+                self.bot._open_or_update_rolling_pr(
+                    repo_root=repo,
+                    staged_paths=[Path("state/upstream-release-bot.json")],
+                    base_branch="main",
+                    branch_name="upstream-release/rolling",
+                    title="chore(registry): update upstream releases",
+                    body="## Summary\n- test\n",
+                )
+
+        validate_generated_paths.assert_not_called()
+        self.assertIn(["gh", "pr", "merge", "12", "--auto", "--squash"], calls)
+
+    def test_reconcile_empty_rolling_pr_resets_branch_and_closes_stale_pr(self) -> None:
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, *, cwd):
+            calls.append(cmd)
+            stdout = ""
+            if cmd == ["git", "rev-parse", "refs/remotes/origin/upstream-release/rolling"]:
+                stdout = "abc123\n"
+            if cmd[:4] == ["gh", "pr", "list", "--head"]:
+                stdout = '[{"number": 12}]'
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        with tempfile.TemporaryDirectory(prefix="release-bot-pr-") as tmp:
+            repo = Path(tmp)
+            with mock.patch.object(self.bot, "_run", side_effect=fake_run), mock.patch.object(
+                self.bot, "_remote_branch_exists", return_value=True
+            ):
+                self.bot._reconcile_empty_rolling_pr(
+                    repo_root=repo,
+                    base_branch="main",
+                    branch_name="upstream-release/rolling",
+                )
+
+        self.assertIn(
+            [
+                "git",
+                "push",
+                "--force-with-lease=refs/heads/upstream-release/rolling:abc123",
+                "origin",
+                "origin/main:refs/heads/upstream-release/rolling",
+            ],
+            calls,
+        )
+        self.assertIn(
+            [
+                "gh",
+                "pr",
+                "close",
+                "12",
+                "--comment",
+                "Closing stale rolling release PR: no generated changes remain.",
+            ],
+            calls,
         )
 
     def test_open_or_update_rolling_pr_force_with_lease_works_without_tracking_ref(self) -> None:

--- a/tests/test_upstream_release_bot.py
+++ b/tests/test_upstream_release_bot.py
@@ -77,7 +77,10 @@ class UpstreamReleaseBotTests(unittest.TestCase):
         with tempfile.TemporaryDirectory(prefix="release-bot-state-") as tmp:
             state = self.bot.load_bot_state(Path(tmp) / "state" / "upstream-release-bot.json")
 
-        self.assertEqual(state, {"schema_version": 1, "sources": {}})
+        self.assertEqual(
+            state,
+            {"schema_version": 2, "sources": {}, "packages": {}, "quarantine": {}},
+        )
 
     def test_load_bot_state_warns_and_rebuilds_when_invalid(self) -> None:
         with tempfile.TemporaryDirectory(prefix="release-bot-state-") as tmp:
@@ -89,7 +92,10 @@ class UpstreamReleaseBotTests(unittest.TestCase):
             with contextlib.redirect_stderr(stderr):
                 state = self.bot.load_bot_state(state_path)
 
-        self.assertEqual(state, {"schema_version": 1, "sources": {}})
+        self.assertEqual(
+            state,
+            {"schema_version": 2, "sources": {}, "packages": {}, "quarantine": {}},
+        )
         self.assertIn("Ignoring invalid release bot state", stderr.getvalue())
 
     def test_write_bot_state_sorts_keys_and_creates_parent(self) -> None:
@@ -99,24 +105,140 @@ class UpstreamReleaseBotTests(unittest.TestCase):
             self.bot.write_bot_state(
                 state_path,
                 {
-                    "schema_version": 1,
+                    "schema_version": 2,
                     "sources": {
                         "github_releases:z/z": {"etag": "z"},
                         "github_releases:a/a": {"etag": "a"},
                     },
+                    "packages": {},
+                    "quarantine": {},
                 },
             )
 
             self.assertEqual(
                 json.loads(state_path.read_text(encoding="utf-8")),
                 {
-                    "schema_version": 1,
+                    "packages": {},
+                    "quarantine": {},
+                    "schema_version": 2,
                     "sources": {
                         "github_releases:a/a": {"etag": "a"},
                         "github_releases:z/z": {"etag": "z"},
                     },
                 },
             )
+
+    def test_load_bot_state_migrates_v1_sources_to_v2(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-state-") as tmp:
+            state_path = Path(tmp) / "state" / "upstream-release-bot.json"
+            state_path.parent.mkdir(parents=True)
+            state_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "sources": {
+                            "github_releases:BurntSushi/ripgrep": {
+                                "etag": "abc",
+                                "latest_version": "15.2.0",
+                            }
+                        },
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            state = self.bot.load_bot_state(state_path)
+
+        self.assertEqual(state["schema_version"], 2)
+        self.assertEqual(
+            state["sources"]["github_releases:BurntSushi/ripgrep"]["etag"], "abc"
+        )
+        self.assertEqual(state["packages"], {})
+        self.assertEqual(state["quarantine"], {})
+
+    def test_write_bot_state_v2_sorts_all_top_level_maps(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-state-") as tmp:
+            state_path = Path(tmp) / "state" / "upstream-release-bot.json"
+
+            self.bot.write_bot_state(
+                state_path,
+                {
+                    "schema_version": 2,
+                    "sources": {"z": {"etag": "z"}, "a": {"etag": "a"}},
+                    "packages": {"zpkg": {"latest_version": "2.0.0"}, "apkg": {}},
+                    "quarantine": {"zpkg": {"reason_code": "metadata-malformed"}, "apkg": {}},
+                },
+            )
+
+            written = json.loads(state_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(
+            list(written.keys()), ["packages", "quarantine", "schema_version", "sources"]
+        )
+        self.assertEqual(list(written["sources"].keys()), ["a", "z"])
+        self.assertEqual(list(written["packages"].keys()), ["apkg", "zpkg"])
+        self.assertEqual(list(written["quarantine"].keys()), ["apkg", "zpkg"])
+
+    def test_rate_limit_reset_header_sets_backoff_until(self) -> None:
+        headers = Message()
+        headers["x-ratelimit-reset"] = "1770000000"
+        error = urllib.error.HTTPError(
+            "https://api.github.com/repos/o/r/releases", 403, "rate limit", headers, None
+        )
+
+        backoff = self.bot.backoff_from_http_error(error, now_epoch=1769999900)
+
+        self.assertEqual(backoff["reason_code"], "rate-limited")
+        self.assertEqual(backoff["backoff_until"], "2026-02-02T02:40:00Z")
+
+    def test_should_skip_package_when_backoff_is_active(self) -> None:
+        entry = {"backoff_until": "2099-01-01T00:00:00Z"}
+
+        self.assertTrue(
+            self.bot.package_backoff_active(entry, now_iso="2026-05-04T12:00:00Z")
+        )
+
+    def test_should_not_skip_package_when_backoff_expired(self) -> None:
+        entry = {"backoff_until": "2026-05-04T11:59:59Z"}
+
+        self.assertFalse(
+            self.bot.package_backoff_active(entry, now_iso="2026-05-04T12:00:00Z")
+        )
+
+    def test_quarantine_update_preserves_first_seen(self) -> None:
+        state = self.bot.empty_bot_state()
+        quarantine = state["quarantine"]
+        quarantine["zig"] = {
+            "reason_code": "metadata-malformed",
+            "first_seen_at": "2026-05-04T10:00:00Z",
+            "last_seen_at": "2026-05-04T10:00:00Z",
+            "attempted_version": "0.16.0",
+            "last_good_version": "0.15.2",
+        }
+
+        changed = self.bot.quarantine_package(
+            state,
+            package="zig",
+            reason_code="metadata-malformed",
+            detail="missing artifact url",
+            attempted_version="0.16.1",
+            last_good_version="0.15.2",
+            now_iso="2026-05-04T11:00:00Z",
+        )
+
+        self.assertTrue(changed)
+        self.assertEqual(quarantine["zig"]["first_seen_at"], "2026-05-04T10:00:00Z")
+        self.assertEqual(quarantine["zig"]["last_seen_at"], "2026-05-04T11:00:00Z")
+        self.assertEqual(quarantine["zig"]["attempted_version"], "0.16.1")
+
+    def test_clear_quarantine_returns_true_only_when_entry_exists(self) -> None:
+        state = self.bot.empty_bot_state()
+        state["quarantine"]["zig"] = {"reason_code": "metadata-malformed"}
+
+        self.assertTrue(self.bot.clear_quarantine(state, package="zig"))
+        self.assertFalse(self.bot.clear_quarantine(state, package="zig"))
+        self.assertNotIn("zig", state["quarantine"])
 
     def test_fetch_github_releases_sends_conditional_headers(self) -> None:
         captured: dict[str, str | None] = {}
@@ -293,6 +415,69 @@ class UpstreamReleaseBotTests(unittest.TestCase):
 
         self.assertEqual(planned, [])
 
+    def test_main_counts_checked_package_with_no_planned_update_as_up_to_date(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-") as tmp:
+            tmp_path = Path(tmp)
+            packages_dir = tmp_path / "packages"
+            packages_dir.mkdir(parents=True)
+            (packages_dir / "ripgrep.toml").write_text(
+                textwrap.dedent(
+                    """
+                    name = "ripgrep"
+                    license = "MIT OR Unlicense"
+                    homepage = "https://github.com/BurntSushi/ripgrep"
+
+                    [source.release]
+                    kind = "github_releases"
+                    repo = "BurntSushi/ripgrep"
+
+                    [source.checksum]
+                    kind = "asset_digest"
+
+                    [source.asset]
+                    kind = "release_asset_url"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            existing_manifest = tmp_path / "releases" / "ripgrep" / "15.2.0.toml"
+            existing_manifest.parent.mkdir(parents=True)
+            existing_manifest.write_text('name = "ripgrep"\nversion = "15.2.0"\n', encoding="utf-8")
+
+            stdout = io.StringIO()
+            generator = load_generator_module()
+            previous_cwd = Path.cwd()
+            os.chdir(tmp_path)
+            try:
+                with (
+                    mock.patch.object(self.bot, "_load_generator_module", return_value=generator),
+                    mock.patch.object(
+                        self.bot,
+                        "fetch_github_releases",
+                        return_value=self.bot.GithubReleaseFetchResult(
+                            releases=[
+                                {
+                                    "tag_name": "15.2.0",
+                                    "draft": False,
+                                    "prerelease": False,
+                                    "assets": [],
+                                }
+                            ]
+                        ),
+                    ),
+                    contextlib.redirect_stdout(stdout),
+                ):
+                    result = self.bot.main(["--package", "ripgrep"])
+            finally:
+                os.chdir(previous_cwd)
+
+        self.assertEqual(result, 0)
+        self.assertIn(
+            "registry_update_summary updated=0 up_to_date=1 quarantined=0 transient_failed=0 skipped=0",
+            stdout.getvalue(),
+        )
+
     def test_plan_updates_python_build_standalone_from_asset_version(self) -> None:
         with tempfile.TemporaryDirectory(prefix="release-bot-") as tmp:
             tmp_path = Path(tmp)
@@ -429,6 +614,10 @@ class UpstreamReleaseBotTests(unittest.TestCase):
             self.assertIn("Skipping fd 10.4.1: incomplete upstream release", stderr.getvalue())
             self.assertIn("skipped 1 incomplete update(s)", stdout.getvalue())
             self.assertIn("wrote 0 release manifest(s)", stdout.getvalue())
+            self.assertIn(
+                "registry_update_summary updated=0 up_to_date=0 quarantined=1 transient_failed=0 skipped=0",
+                stdout.getvalue(),
+            )
 
     def test_skips_release_fetch_http_error_instead_of_failing(self) -> None:
         with tempfile.TemporaryDirectory(prefix="release-bot-") as tmp:
@@ -462,6 +651,7 @@ class UpstreamReleaseBotTests(unittest.TestCase):
             generator = load_generator_module()
             headers = Message()
             headers["x-ratelimit-remaining"] = "0"
+            headers["x-ratelimit-reset"] = "1770000000"
             previous_cwd = Path.cwd()
             os.chdir(tmp_path)
             try:
@@ -497,6 +687,192 @@ class UpstreamReleaseBotTests(unittest.TestCase):
             )
             self.assertIn("skipped 1 release fetch(es)", stdout.getvalue())
             self.assertIn("No new releases detected", stdout.getvalue())
+            self.assertIn(
+                "registry_update package=trivy status=skipped reason=rate-limited reset_at=2026-02-02T02:40:00Z",
+                stderr.getvalue(),
+            )
+            self.assertIn(
+                "registry_update_summary updated=0 up_to_date=0 quarantined=0 transient_failed=1 skipped=1",
+                stdout.getvalue(),
+            )
+
+    def test_transient_fetch_failure_is_package_scoped_and_continues(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-") as tmp:
+            tmp_path = Path(tmp)
+            packages_dir = tmp_path / "packages"
+            packages_dir.mkdir(parents=True)
+            (packages_dir / "trivy.toml").write_text(
+                textwrap.dedent(
+                    """
+                    name = "trivy"
+                    license = "Apache-2.0"
+                    homepage = "https://github.com/aquasecurity/trivy"
+
+                    [source.release]
+                    kind = "github_releases"
+                    repo = "aquasecurity/trivy"
+
+                    [source.checksum]
+                    kind = "asset_digest"
+
+                    [source.asset]
+                    kind = "release_asset_url"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            (packages_dir / "ripgrep.toml").write_text(
+                textwrap.dedent(
+                    """
+                    name = "ripgrep"
+                    license = "MIT OR Unlicense"
+                    homepage = "https://github.com/BurntSushi/ripgrep"
+
+                    [source.release]
+                    kind = "github_releases"
+                    repo = "BurntSushi/ripgrep"
+
+                    [source.checksum]
+                    kind = "asset_digest"
+
+                    [source.asset]
+                    kind = "release_asset_url"
+
+                    [[artifacts]]
+                    target = "x86_64-unknown-linux-gnu"
+                    asset = "ripgrep-{version}-x86_64-unknown-linux-musl.tar.gz"
+                    archive = "tar.gz"
+                    strip_components = 1
+
+                    [[artifacts.binaries]]
+                    name = "rg"
+                    path = "rg"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            generator = load_generator_module()
+            previous_cwd = Path.cwd()
+            os.chdir(tmp_path)
+            try:
+                with (
+                    mock.patch.object(self.bot, "_load_generator_module", return_value=generator),
+                    mock.patch.object(self.bot, "utc_now_iso", return_value="2026-05-04T12:00:00Z"),
+                    mock.patch.object(self.bot, "validate_package_generated_paths"),
+                    mock.patch.object(
+                        self.bot,
+                        "fetch_github_releases",
+                        side_effect=[
+                            self.bot.GithubReleaseFetchResult(
+                                releases=[
+                                    {
+                                        "tag_name": "15.2.0",
+                                        "draft": False,
+                                        "prerelease": False,
+                                        "assets": [
+                                            {
+                                                "name": "ripgrep-15.2.0-x86_64-unknown-linux-musl.tar.gz",
+                                                "browser_download_url": "https://example.invalid/ripgrep.tar.gz",
+                                                "digest": "sha256:88fd1ce767091fd8d4a99fdb2356e98c819f93f3b1f8663853a2dee9b438068a",
+                                            }
+                                        ],
+                                    }
+                                ]
+                            ),
+                            urllib.error.HTTPError(
+                                "https://api.github.com/repos/aquasecurity/trivy/releases?per_page=20",
+                                500,
+                                "Server Error",
+                                Message(),
+                                None,
+                            ),
+                        ],
+                    ),
+                    contextlib.redirect_stdout(stdout),
+                    contextlib.redirect_stderr(stderr),
+                ):
+                    result = self.bot.main([])
+            finally:
+                os.chdir(previous_cwd)
+
+            state = json.loads((tmp_path / "state" / "upstream-release-bot.json").read_text(encoding="utf-8"))
+            ripgrep_release_exists = (tmp_path / "releases" / "ripgrep" / "15.2.0.toml").exists()
+
+        self.assertEqual(result, 0)
+        self.assertTrue(ripgrep_release_exists)
+        self.assertIn(
+            "registry_update package=trivy status=skipped reason=upstream-error reset_at=2026-05-04T13:00:00Z",
+            stderr.getvalue(),
+        )
+        self.assertIn(
+            "registry_update_summary updated=1 up_to_date=0 quarantined=0 transient_failed=1 skipped=1",
+            stdout.getvalue(),
+        )
+        self.assertEqual(state["packages"]["trivy"]["reason_code"], "upstream-error")
+        self.assertEqual(state["packages"]["trivy"]["backoff_until"], "2026-05-04T13:00:00Z")
+
+    def test_url_timeout_fetch_failure_is_package_scoped(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-") as tmp:
+            tmp_path = Path(tmp)
+            packages_dir = tmp_path / "packages"
+            packages_dir.mkdir(parents=True)
+            (packages_dir / "trivy.toml").write_text(
+                textwrap.dedent(
+                    """
+                    name = "trivy"
+                    license = "Apache-2.0"
+                    homepage = "https://github.com/aquasecurity/trivy"
+
+                    [source.release]
+                    kind = "github_releases"
+                    repo = "aquasecurity/trivy"
+
+                    [source.checksum]
+                    kind = "asset_digest"
+
+                    [source.asset]
+                    kind = "release_asset_url"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            generator = load_generator_module()
+            previous_cwd = Path.cwd()
+            os.chdir(tmp_path)
+            try:
+                with (
+                    mock.patch.object(self.bot, "_load_generator_module", return_value=generator),
+                    mock.patch.object(self.bot, "utc_now_iso", return_value="2026-05-04T12:00:00Z"),
+                    mock.patch.object(
+                        self.bot,
+                        "fetch_github_releases",
+                        side_effect=urllib.error.URLError("timed out"),
+                    ),
+                    contextlib.redirect_stdout(stdout),
+                    contextlib.redirect_stderr(stderr),
+                ):
+                    result = self.bot.main(["--package", "trivy"])
+            finally:
+                os.chdir(previous_cwd)
+
+        self.assertEqual(result, 0)
+        self.assertIn(
+            "registry_update package=trivy status=skipped reason=upstream-error reset_at=2026-05-04T13:00:00Z",
+            stderr.getvalue(),
+        )
+        self.assertIn(
+            "registry_update_summary updated=0 up_to_date=0 quarantined=0 transient_failed=1 skipped=1",
+            stdout.getvalue(),
+        )
 
     def test_release_fetch_non_rate_http_error_still_fails(self) -> None:
         with tempfile.TemporaryDirectory(prefix="release-bot-") as tmp:
@@ -552,6 +928,110 @@ class UpstreamReleaseBotTests(unittest.TestCase):
             finally:
                 os.chdir(previous_cwd)
 
+    def test_github_403_without_rate_limit_signal_still_fails(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-") as tmp:
+            tmp_path = Path(tmp)
+            packages_dir = tmp_path / "packages"
+            packages_dir.mkdir(parents=True)
+            (packages_dir / "private.toml").write_text(
+                textwrap.dedent(
+                    """
+                    name = "private"
+                    license = "MIT"
+                    homepage = "https://github.com/example/private"
+
+                    [source.release]
+                    kind = "github_releases"
+                    repo = "example/private"
+
+                    [source.checksum]
+                    kind = "asset_digest"
+
+                    [source.asset]
+                    kind = "release_asset_url"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            generator = load_generator_module()
+            previous_cwd = Path.cwd()
+            os.chdir(tmp_path)
+            try:
+                with (
+                    mock.patch.object(self.bot, "_load_generator_module", return_value=generator),
+                    mock.patch.object(self.bot, "utc_now_iso", return_value="2026-05-04T12:00:00Z"),
+                    mock.patch.object(
+                        self.bot,
+                        "fetch_github_releases",
+                        side_effect=urllib.error.HTTPError(
+                            "https://api.github.com/repos/example/private/releases?per_page=20",
+                            403,
+                            "Forbidden",
+                            Message(),
+                            None,
+                        ),
+                    ),
+                ):
+                    with self.assertRaises(urllib.error.HTTPError):
+                        self.bot.main(["--package", "private"])
+            finally:
+                os.chdir(previous_cwd)
+
+    def test_github_403_with_reset_but_no_rate_limit_signal_still_fails(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-") as tmp:
+            tmp_path = Path(tmp)
+            packages_dir = tmp_path / "packages"
+            packages_dir.mkdir(parents=True)
+            (packages_dir / "private.toml").write_text(
+                textwrap.dedent(
+                    """
+                    name = "private"
+                    license = "MIT"
+                    homepage = "https://github.com/example/private"
+
+                    [source.release]
+                    kind = "github_releases"
+                    repo = "example/private"
+
+                    [source.checksum]
+                    kind = "asset_digest"
+
+                    [source.asset]
+                    kind = "release_asset_url"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            headers = Message()
+            headers["x-ratelimit-reset"] = "1770000000"
+            headers["x-ratelimit-remaining"] = "42"
+            generator = load_generator_module()
+            previous_cwd = Path.cwd()
+            os.chdir(tmp_path)
+            try:
+                with (
+                    mock.patch.object(self.bot, "_load_generator_module", return_value=generator),
+                    mock.patch.object(
+                        self.bot,
+                        "fetch_github_releases",
+                        side_effect=urllib.error.HTTPError(
+                            "https://api.github.com/repos/example/private/releases?per_page=20",
+                            403,
+                            "Forbidden",
+                            headers,
+                            None,
+                        ),
+                    ),
+                ):
+                    with self.assertRaises(urllib.error.HTTPError):
+                        self.bot.main(["--package", "private"])
+            finally:
+                os.chdir(previous_cwd)
+
     def test_main_skips_planning_when_github_release_not_modified(self) -> None:
         with tempfile.TemporaryDirectory(prefix="release-bot-") as tmp:
             tmp_path = Path(tmp)
@@ -579,12 +1059,16 @@ class UpstreamReleaseBotTests(unittest.TestCase):
                 encoding="utf-8",
             )
             state_path = tmp_path / "state" / "upstream-release-bot.json"
-            self.bot.write_bot_state(
-                state_path,
-                {
-                    "schema_version": 1,
-                    "sources": {"github_releases:aquasecurity/trivy": {"etag": "abc"}},
-                },
+            state_path.parent.mkdir(parents=True)
+            state_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "sources": {"github_releases:aquasecurity/trivy": {"etag": "abc"}},
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
             )
             stdout = io.StringIO()
             generator = load_generator_module()
@@ -593,6 +1077,7 @@ class UpstreamReleaseBotTests(unittest.TestCase):
             try:
                 with (
                     mock.patch.object(self.bot, "_load_generator_module", return_value=generator),
+                    mock.patch.object(self.bot, "utc_now_iso", return_value="2026-05-04T12:00:00Z"),
                     mock.patch.object(
                         self.bot,
                         "fetch_github_releases",
@@ -605,10 +1090,33 @@ class UpstreamReleaseBotTests(unittest.TestCase):
                     result = self.bot.main(["--package", "trivy"])
             finally:
                 os.chdir(previous_cwd)
+            persisted_state = json.loads(state_path.read_text(encoding="utf-8"))
 
         self.assertEqual(result, 0)
         fetch.assert_called_once()
         self.assertIn("No new releases detected", stdout.getvalue())
+        self.assertEqual(
+            persisted_state,
+            {
+                "packages": {
+                    "trivy": {
+                        "last_checked_at": "2026-05-04T12:00:00Z",
+                        "source_identity": "github_releases:aquasecurity/trivy",
+                        "source_kind": "github_releases",
+                    }
+                },
+                "quarantine": {},
+                "schema_version": 2,
+                "sources": {
+                    "github_releases:aquasecurity/trivy": {
+                        "etag": "abc",
+                        "last_checked_at": "2026-05-04T12:00:00Z",
+                        "source_identity": "github_releases:aquasecurity/trivy",
+                        "source_kind": "github_releases",
+                    }
+                },
+            },
+        )
 
     def test_main_refreshes_state_after_successful_github_fetch_with_update(self) -> None:
         with tempfile.TemporaryDirectory(prefix="release-bot-") as tmp:
@@ -646,6 +1154,27 @@ class UpstreamReleaseBotTests(unittest.TestCase):
                 + "\n",
                 encoding="utf-8",
             )
+            state_path = tmp_path / "state" / "upstream-release-bot.json"
+            state_path.parent.mkdir(parents=True)
+            state_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "sources": {},
+                        "packages": {
+                            "ripgrep": {
+                                "reason_code": "rate-limited",
+                                "backoff_until": "2026-04-28T11:00:00Z",
+                                "detail": "HTTP 403 rate limit",
+                                "last_failed_at": "2026-04-28T10:00:00Z",
+                            }
+                        },
+                        "quarantine": {},
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
             generator = load_generator_module()
             previous_cwd = Path.cwd()
             os.chdir(tmp_path)
@@ -653,6 +1182,7 @@ class UpstreamReleaseBotTests(unittest.TestCase):
                 with (
                     mock.patch.object(self.bot, "_load_generator_module", return_value=generator),
                     mock.patch.object(self.bot, "utc_now_iso", return_value="2026-04-28T12:00:00Z"),
+                    mock.patch.object(self.bot, "validate_package_generated_paths"),
                     mock.patch.object(
                         self.bot,
                         "fetch_github_releases",
@@ -694,6 +1224,20 @@ class UpstreamReleaseBotTests(unittest.TestCase):
                 "last_modified": "Tue, 28 Apr 2026 12:00:00 GMT",
                 "last_checked_at": "2026-04-28T12:00:00Z",
                 "latest_version": "15.2.0",
+                "latest_seen_version": "15.2.0",
+                "source_identity": "github_releases:BurntSushi/ripgrep",
+                "source_kind": "github_releases",
+            },
+        )
+        self.assertEqual(
+            state["packages"]["ripgrep"],
+            {
+                "last_checked_at": "2026-04-28T12:00:00Z",
+                "last_generated_at": "2026-04-28T12:00:00Z",
+                "last_successful_version": "15.2.0",
+                "latest_seen_version": "15.2.0",
+                "source_identity": "github_releases:BurntSushi/ripgrep",
+                "source_kind": "github_releases",
             },
         )
 
@@ -784,6 +1328,35 @@ class UpstreamReleaseBotTests(unittest.TestCase):
                     staged_paths=[Path("scripts/upstream-release-bot.py")],
                 )
 
+    def test_render_pr_body_includes_deterministic_audit_details(self) -> None:
+        body = self.bot.render_pr_body(
+            updated_packages=["ripgrep@15.2.0"],
+            quarantine_added=["zig"],
+            quarantine_updated=["fd"],
+            quarantine_cleared=["node"],
+            backoff_packages=["trivy:rate-limited:2026-02-02T02:40:00Z"],
+            state_changed=True,
+            created_releases=1,
+            written_packages=1,
+            quarantined_count=2,
+            transient_failures=1,
+            skipped_fetches=1,
+        )
+
+        self.assertIn("- state changed: yes", body)
+        self.assertIn("- quarantine added: zig", body)
+        self.assertIn("- quarantine updated: fd", body)
+        self.assertIn("- quarantine cleared: node", body)
+        self.assertIn("- backoff packages: trivy:rate-limited:2026-02-02T02:40:00Z", body)
+
+    def test_workflow_serializes_fixed_rolling_branch_runs(self) -> None:
+        workflow = (REPO_ROOT / ".github" / "workflows" / "upstream-release-bot.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("group: upstream-release-bot-upstream-release-rolling", workflow)
+        self.assertNotIn("github.ref", workflow)
+
     def test_open_or_update_pr_enables_automerge_for_new_pr(self) -> None:
         with tempfile.TemporaryDirectory(prefix="release-bot-pr-") as tmp:
             repo = Path(tmp)
@@ -822,6 +1395,344 @@ class UpstreamReleaseBotTests(unittest.TestCase):
 
         self.assertIn(
             ["gh", "pr", "merge", "upstream-release/ripgrep/15.2.0", "--auto", "--squash"],
+            calls,
+        )
+
+    def test_open_or_update_rolling_pr_regenerates_branch_from_base(self) -> None:
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, *, cwd):
+            calls.append(cmd)
+            stdout = ""
+            if cmd[:4] == ["gh", "pr", "list", "--head"]:
+                stdout = "[]"
+            if cmd == ["git", "diff", "--cached", "--name-only"]:
+                stdout = "packages/ripgrep.toml\n"
+            if cmd == ["git", "rev-parse", "refs/remotes/origin/upstream-release/rolling"]:
+                stdout = "abc123\n"
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        with tempfile.TemporaryDirectory(prefix="release-bot-pr-") as tmp:
+            repo = Path(tmp)
+            (repo / "packages").mkdir()
+            (repo / "packages" / "ripgrep.toml").write_text(
+                'name = "ripgrep"\n', encoding="utf-8"
+            )
+            with mock.patch.object(self.bot, "_run", side_effect=fake_run), mock.patch.object(
+                self.bot, "validate_generated_paths"
+            ), mock.patch.object(self.bot, "_remote_branch_exists", return_value=True):
+                self.bot._open_or_update_rolling_pr(
+                    repo_root=repo,
+                    staged_paths=[Path("packages/ripgrep.toml")],
+                    base_branch="main",
+                    branch_name="upstream-release/rolling",
+                    title="chore(registry): update upstream releases",
+                    body="## Summary\n- test\n",
+                )
+
+        self.assertIn(["git", "fetch", "origin", "main"], calls)
+        self.assertIn(
+            ["git", "switch", "-C", "upstream-release/rolling", "origin/main"], calls
+        )
+        self.assertIn(
+            [
+                "git",
+                "push",
+                "--force-with-lease=refs/heads/upstream-release/rolling:abc123",
+                "-u",
+                "origin",
+                "upstream-release/rolling",
+            ],
+            calls,
+        )
+
+    def test_open_or_update_rolling_pr_fetches_branch_before_force_with_lease(self) -> None:
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, *, cwd):
+            calls.append(cmd)
+            stdout = ""
+            if cmd[:4] == ["gh", "pr", "list", "--head"]:
+                stdout = "[]"
+            if cmd == ["git", "diff", "--cached", "--name-only"]:
+                stdout = "packages/ripgrep.toml\n"
+            if cmd == ["git", "rev-parse", "refs/remotes/origin/upstream-release/rolling"]:
+                stdout = "abc123\n"
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        with tempfile.TemporaryDirectory(prefix="release-bot-pr-") as tmp:
+            repo = Path(tmp)
+            (repo / "packages").mkdir()
+            (repo / "packages" / "ripgrep.toml").write_text(
+                'name = "ripgrep"\n', encoding="utf-8"
+            )
+            with mock.patch.object(self.bot, "_run", side_effect=fake_run), mock.patch.object(
+                self.bot, "validate_generated_paths"
+            ), mock.patch.object(self.bot, "_remote_branch_exists", return_value=True):
+                self.bot._open_or_update_rolling_pr(
+                    repo_root=repo,
+                    staged_paths=[Path("packages/ripgrep.toml")],
+                    base_branch="main",
+                    branch_name="upstream-release/rolling",
+                    title="chore(registry): update upstream releases",
+                    body="## Summary\n- test\n",
+                )
+
+        push_index = calls.index(
+            [
+                "git",
+                "push",
+                "--force-with-lease=refs/heads/upstream-release/rolling:abc123",
+                "-u",
+                "origin",
+                "upstream-release/rolling",
+            ]
+        )
+        self.assertIn(
+            [
+                "git",
+                "fetch",
+                "origin",
+                "+refs/heads/upstream-release/rolling:refs/remotes/origin/upstream-release/rolling",
+            ],
+            calls[:push_index],
+        )
+
+    def test_open_or_update_rolling_pr_force_with_lease_works_without_tracking_ref(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-git-") as tmp:
+            tmp_path = Path(tmp)
+            remote = tmp_path / "remote.git"
+            seed = tmp_path / "seed"
+            repo = tmp_path / "repo"
+            subprocess.run(["git", "init", "--bare", remote], check=True)
+            subprocess.run(["git", "init", "-b", "main", seed], check=True)
+
+            self._git(seed, "config", "user.name", "Test User")
+            self._git(seed, "config", "user.email", "test@example.com")
+            self._git(seed, "remote", "add", "origin", str(remote))
+            (seed / "README.md").write_text("base\n", encoding="utf-8")
+            self._git(seed, "add", "README.md")
+            self._git(seed, "commit", "-m", "base")
+            self._git(seed, "push", "-u", "origin", "main")
+
+            self._git(seed, "switch", "-c", "upstream-release/rolling")
+            (seed / "packages").mkdir()
+            (seed / "packages" / "old.toml").write_text('name = "old"\n', encoding="utf-8")
+            self._git(seed, "add", "packages/old.toml")
+            self._git(seed, "commit", "-m", "old rolling branch")
+            self._git(seed, "push", "-u", "origin", "upstream-release/rolling")
+
+            subprocess.run(
+                [
+                    "git",
+                    "clone",
+                    "--single-branch",
+                    "--branch",
+                    "main",
+                    str(remote),
+                    str(repo),
+                ],
+                check=True,
+            )
+            self._git(repo, "config", "user.name", "Test User")
+            self._git(repo, "config", "user.email", "test@example.com")
+            self.assertNotIn(
+                "origin/upstream-release/rolling",
+                self._git(repo, "branch", "-r"),
+            )
+
+            package_path = repo / "packages" / "ripgrep.toml"
+            package_path.parent.mkdir()
+            package_path.write_text('name = "ripgrep"\n', encoding="utf-8")
+
+            fake_bin = tmp_path / "bin"
+            fake_bin.mkdir()
+            gh = fake_bin / "gh"
+            gh.write_text(
+                textwrap.dedent(
+                    """
+                    #!/usr/bin/env python3
+                    import sys
+
+                    if sys.argv[1:4] == ["pr", "list", "--head"]:
+                        print("[]")
+                    elif sys.argv[1:3] == ["pr", "create"]:
+                        print("created")
+                    elif sys.argv[1:3] == ["pr", "merge"]:
+                        print("automerge enabled")
+                    else:
+                        raise SystemExit(f"unexpected gh args: {sys.argv[1:]}")
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            gh.chmod(0o755)
+
+            previous_path = os.environ.get("PATH", "")
+            os.environ["PATH"] = f"{fake_bin}:{previous_path}"
+            try:
+                with mock.patch.object(self.bot, "validate_generated_paths"):
+                    self.bot._open_or_update_rolling_pr(
+                        repo_root=repo,
+                        staged_paths=[package_path.relative_to(repo)],
+                        base_branch="main",
+                        branch_name="upstream-release/rolling",
+                        title="chore(registry): update upstream releases",
+                        body="## Summary\n- test\n",
+                    )
+            finally:
+                os.environ["PATH"] = previous_path
+
+            self.assertIn(
+                "origin/upstream-release/rolling",
+                self._git(repo, "branch", "-r"),
+            )
+            remote_package = subprocess.run(
+                [
+                    "git",
+                    f"--git-dir={remote}",
+                    "show",
+                    "refs/heads/upstream-release/rolling:packages/ripgrep.toml",
+                ],
+                check=True,
+                text=True,
+                capture_output=True,
+            ).stdout
+            self.assertEqual(
+                'name = "ripgrep"\n',
+                remote_package,
+            )
+
+    def test_open_or_update_rolling_pr_refreshes_stale_tracking_ref_with_force_fetch(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-git-") as tmp:
+            tmp_path = Path(tmp)
+            remote = tmp_path / "remote.git"
+            seed = tmp_path / "seed"
+            repo = tmp_path / "repo"
+            subprocess.run(["git", "init", "--bare", remote], check=True)
+            subprocess.run(["git", "init", "-b", "main", seed], check=True)
+
+            self._git(seed, "config", "user.name", "Test User")
+            self._git(seed, "config", "user.email", "test@example.com")
+            self._git(seed, "remote", "add", "origin", str(remote))
+            (seed / "README.md").write_text("base\n", encoding="utf-8")
+            self._git(seed, "add", "README.md")
+            self._git(seed, "commit", "-m", "base")
+            self._git(seed, "push", "-u", "origin", "main")
+
+            self._git(seed, "switch", "-c", "upstream-release/rolling")
+            (seed / "packages").mkdir()
+            (seed / "packages" / "old.toml").write_text('name = "old"\n', encoding="utf-8")
+            self._git(seed, "add", "packages/old.toml")
+            self._git(seed, "commit", "-m", "old rolling branch")
+            self._git(seed, "push", "-u", "origin", "upstream-release/rolling")
+
+            subprocess.run(["git", "clone", str(remote), str(repo)], check=True)
+            self._git(repo, "config", "user.name", "Test User")
+            self._git(repo, "config", "user.email", "test@example.com")
+            self.assertIn("origin/upstream-release/rolling", self._git(repo, "branch", "-r"))
+
+            self._git(seed, "switch", "upstream-release/rolling")
+            self._git(seed, "reset", "--hard", "origin/main")
+            (seed / "packages").mkdir()
+            (seed / "packages" / "new-remote.toml").write_text(
+                'name = "new-remote"\n', encoding="utf-8"
+            )
+            self._git(seed, "add", "packages/new-remote.toml")
+            self._git(seed, "commit", "-m", "rewritten rolling branch")
+            self._git(seed, "push", "--force", "origin", "upstream-release/rolling")
+
+            package_path = repo / "packages" / "ripgrep.toml"
+            package_path.parent.mkdir()
+            package_path.write_text('name = "ripgrep"\n', encoding="utf-8")
+
+            fake_bin = tmp_path / "bin"
+            fake_bin.mkdir()
+            gh = fake_bin / "gh"
+            gh.write_text(
+                textwrap.dedent(
+                    """
+                    #!/usr/bin/env python3
+                    import sys
+
+                    if sys.argv[1:4] == ["pr", "list", "--head"]:
+                        print("[]")
+                    elif sys.argv[1:3] == ["pr", "create"]:
+                        print("created")
+                    elif sys.argv[1:3] == ["pr", "merge"]:
+                        print("automerge enabled")
+                    else:
+                        raise SystemExit(f"unexpected gh args: {sys.argv[1:]}")
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            gh.chmod(0o755)
+
+            previous_path = os.environ.get("PATH", "")
+            os.environ["PATH"] = f"{fake_bin}:{previous_path}"
+            try:
+                with mock.patch.object(self.bot, "validate_generated_paths"):
+                    self.bot._open_or_update_rolling_pr(
+                        repo_root=repo,
+                        staged_paths=[package_path.relative_to(repo)],
+                        base_branch="main",
+                        branch_name="upstream-release/rolling",
+                        title="chore(registry): update upstream releases",
+                        body="## Summary\n- test\n",
+                    )
+            finally:
+                os.environ["PATH"] = previous_path
+
+            remote_package = subprocess.run(
+                [
+                    "git",
+                    f"--git-dir={remote}",
+                    "show",
+                    "refs/heads/upstream-release/rolling:packages/ripgrep.toml",
+                ],
+                check=True,
+                text=True,
+                capture_output=True,
+            ).stdout
+            self.assertEqual('name = "ripgrep"\n', remote_package)
+
+    def test_open_or_update_rolling_pr_does_not_fetch_missing_remote_branch(self) -> None:
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, *, cwd):
+            calls.append(cmd)
+            if cmd == ["git", "fetch", "origin", "upstream-release/rolling"]:
+                self.fail("missing rolling branch should not be fetched")
+            stdout = ""
+            if cmd[:4] == ["gh", "pr", "list", "--head"]:
+                stdout = "[]"
+            if cmd == ["git", "diff", "--cached", "--name-only"]:
+                stdout = "packages/ripgrep.toml\n"
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        with tempfile.TemporaryDirectory(prefix="release-bot-pr-") as tmp:
+            repo = Path(tmp)
+            (repo / "packages").mkdir()
+            (repo / "packages" / "ripgrep.toml").write_text(
+                'name = "ripgrep"\n', encoding="utf-8"
+            )
+            with mock.patch.object(self.bot, "_run", side_effect=fake_run), mock.patch.object(
+                self.bot, "validate_generated_paths"
+            ), mock.patch.object(self.bot, "_remote_branch_exists", return_value=False):
+                self.bot._open_or_update_rolling_pr(
+                    repo_root=repo,
+                    staged_paths=[Path("packages/ripgrep.toml")],
+                    base_branch="main",
+                    branch_name="upstream-release/rolling",
+                    title="chore(registry): update upstream releases",
+                    body="## Summary\n- test\n",
+                )
+
+        self.assertIn(
+            ["git", "push", "--force-with-lease", "-u", "origin", "upstream-release/rolling"],
             calls,
         )
 

--- a/tests/test_upstream_release_bot.py
+++ b/tests/test_upstream_release_bot.py
@@ -1554,6 +1554,22 @@ class UpstreamReleaseBotTests(unittest.TestCase):
             ["git", "switch", "-C", "upstream-release/rolling", "origin/main"], calls
         )
         self.assertIn(
+            ["git", "fetch", "origin", "main"],
+            calls,
+        )
+        self.assertLess(
+            calls.index(["git", "fetch", "origin", "main"]),
+            calls.index(
+                [
+                    "git",
+                    "push",
+                    "--force-with-lease=refs/heads/upstream-release/rolling:abc123",
+                    "origin",
+                    "origin/main:refs/heads/upstream-release/rolling",
+                ]
+            ),
+        )
+        self.assertIn(
             [
                 "git",
                 "push",

--- a/tests/test_upstream_release_bot.py
+++ b/tests/test_upstream_release_bot.py
@@ -1165,6 +1165,78 @@ class UpstreamReleaseBotTests(unittest.TestCase):
             },
         )
 
+    def test_create_prs_reconciles_stale_rolling_pr_for_audit_only_state_change(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="release-bot-") as tmp:
+            tmp_path = Path(tmp)
+            packages_dir = tmp_path / "packages"
+            packages_dir.mkdir(parents=True)
+            (packages_dir / "trivy.toml").write_text(
+                textwrap.dedent(
+                    """
+                    name = "trivy"
+                    license = "Apache-2.0"
+                    homepage = "https://github.com/aquasecurity/trivy"
+
+                    [source.release]
+                    kind = "github_releases"
+                    repo = "aquasecurity/trivy"
+
+                    [source.checksum]
+                    kind = "asset_digest"
+
+                    [source.asset]
+                    kind = "release_asset_url"
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            state_path = tmp_path / "state" / "upstream-release-bot.json"
+            state_path.parent.mkdir(parents=True)
+            original_state = {
+                "schema_version": 2,
+                "sources": {"github_releases:aquasecurity/trivy": {"etag": "abc"}},
+                "packages": {},
+                "quarantine": {},
+            }
+            state_path.write_text(json.dumps(original_state) + "\n", encoding="utf-8")
+            stdout = io.StringIO()
+            generator = load_generator_module()
+            previous_cwd = Path.cwd()
+            os.chdir(tmp_path)
+            try:
+                with (
+                    mock.patch.object(self.bot, "_load_generator_module", return_value=generator),
+                    mock.patch.object(self.bot, "_run") as run,
+                    mock.patch.object(self.bot, "utc_now_iso", return_value="2026-05-04T12:00:00Z"),
+                    mock.patch.object(
+                        self.bot,
+                        "fetch_github_releases",
+                        return_value=self.bot.GithubReleaseFetchResult(
+                            releases=[], not_modified=True
+                        ),
+                    ),
+                    mock.patch.object(self.bot, "_reconcile_empty_rolling_pr") as reconcile,
+                    mock.patch.object(self.bot, "_open_or_update_rolling_pr") as open_or_update,
+                    contextlib.redirect_stdout(stdout),
+                ):
+                    result = self.bot.main(["--package", "trivy", "--create-prs"])
+            finally:
+                os.chdir(previous_cwd)
+
+            persisted_state = json.loads(state_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(result, 0)
+        run.assert_any_call(["git", "fetch", "origin", "main"], cwd=tmp_path)
+        reconcile.assert_called_once_with(
+            repo_root=tmp_path,
+            base_branch="main",
+            branch_name="upstream-release/rolling",
+        )
+        open_or_update.assert_not_called()
+        self.assertEqual(persisted_state, original_state)
+        self.assertIn("No new releases detected", stdout.getvalue())
+
     def test_main_refreshes_state_after_successful_github_fetch_with_update(self) -> None:
         with tempfile.TemporaryDirectory(prefix="release-bot-") as tmp:
             tmp_path = Path(tmp)


### PR DESCRIPTION
## Summary
- Add schema v2 state migration, per-package backoff, quarantine, and stable registry update summaries.
- Regenerate the rolling upstream-release PR from current main with safer force-with-lease branch updates.
- Expand bot tests and document operational recovery in the registry update runbook.

## Verification
- python3 -m unittest discover -s tests -q
- git diff --check -- .github/workflows/upstream-release-bot.yml scripts/upstream-release-bot.py scripts/registry-update-runbook.md tests/test_upstream_release_bot.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single rolling PR/branch for updates with rolling concurrency that cancels in-progress runs; deterministic PR summaries.

* **Bug Fixes**
  * Improved rate-limit/backoff handling, quarantining and recovery; safer generation/validation with rollback on failures and deterministic persisted state (schema v2).

* **Documentation**
  * Expanded runbook with validation commands, rolling-bot behavior, migration details and recovery procedures.

* **Tests**
  * Added coverage for schema v2, backoff/quarantine, deterministic PR bodies, branch/PR workflow and reconciliation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->