### PR TITLE
feat(registry): add package manpage integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Official Crosspack registry source.
   - package identity (`name`, `license`, `homepage`)
   - upstream source metadata (`[source]`)
   - artifact template metadata (`target`, `asset`, archive hints, binaries/completions/gui metadata)
-  - typed host integrations (`docker_cli_plugin`, `path_plugin`, or `service`) without arbitrary install scripts
+  - typed host integrations (`docker_cli_plugin`, `man_page`, `path_plugin`, or `service`) without arbitrary install scripts
 - `releases/<package>/<version>.toml` stores version-specific resolved artifact data:
   - `name`, `version`
   - per-target `url` + `sha256`
@@ -85,6 +85,7 @@ Legacy `provider = "github"` and `provider = "nodejs-dist"` source definitions a
 `[[integrations]]` entries declare host-visible integration metadata. Sources are artifact-relative paths and must not be absolute or contain `..` segments.
 
 - `kind = "docker_cli_plugin"` requires `name` and `source`; install projects the source under the Crosspack prefix, while host activation is explicit through `crosspack integrations enable`.
+- `kind = "man_page"` requires `section` and `source`, with optional `name` for single-file declarations and optional `platforms = ["linux", "macos", "windows"]`; install projects matched files under `share/man/man<section>/`, and Unix shell init exposes the Crosspack man root through `MANPATH`.
 - `kind = "path_plugin"` requires `host`, `name`, and `source`; install projects the source under the Crosspack prefix, while host activation is explicit through `crosspack integrations enable`.
 - `kind = "service"` requires `name` and at least one service source: legacy `source`/`linux_systemd_user`, `macos_launch_agent`, or `windows_service`. Service host activation is explicit-only today; registry entries should not set `enable = true`.
 

--- a/packages/gh.toml
+++ b/packages/gh.toml
@@ -66,3 +66,9 @@ strip_components = 1
 [[artifacts.binaries]]
 name = "gh"
 path = "bin/gh.exe"
+
+[[integrations]]
+kind = "man_page"
+platforms = ["linux", "macos"]
+section = "1"
+source = "share/man/man1/*.1"

--- a/packages/mise.toml
+++ b/packages/mise.toml
@@ -34,7 +34,7 @@ strip_components = 0
 
 [[artifacts.binaries]]
 name = "mise"
-path = "mise"
+path = "mise/bin/mise"
 
 [[artifacts]]
 target = "aarch64-unknown-linux-gnu"
@@ -44,7 +44,7 @@ strip_components = 0
 
 [[artifacts.binaries]]
 name = "mise"
-path = "mise"
+path = "mise/bin/mise"
 
 [[artifacts]]
 target = "x86_64-apple-darwin"
@@ -54,7 +54,7 @@ strip_components = 0
 
 [[artifacts.binaries]]
 name = "mise"
-path = "mise"
+path = "mise/bin/mise"
 
 [[artifacts]]
 target = "aarch64-apple-darwin"
@@ -64,7 +64,7 @@ strip_components = 0
 
 [[artifacts.binaries]]
 name = "mise"
-path = "mise"
+path = "mise/bin/mise"
 
 [[artifacts]]
 target = "x86_64-pc-windows-msvc"
@@ -74,7 +74,7 @@ strip_components = 0
 
 [[artifacts.binaries]]
 name = "mise"
-path = "mise.exe"
+path = "mise/bin/mise.exe"
 
 [[artifacts]]
 target = "aarch64-pc-windows-msvc"
@@ -84,4 +84,10 @@ strip_components = 0
 
 [[artifacts.binaries]]
 name = "mise"
-path = "mise.exe"
+path = "mise/bin/mise.exe"
+
+[[integrations]]
+kind = "man_page"
+platforms = ["linux", "macos"]
+section = "1"
+source = "mise/man/man1/*.1"

--- a/packages/neovim.toml
+++ b/packages/neovim.toml
@@ -76,3 +76,9 @@ strip_components = 1
 [[artifacts.binaries]]
 name = "nvim"
 path = "bin/nvim.exe"
+
+[[integrations]]
+kind = "man_page"
+platforms = ["linux", "macos"]
+section = "1"
+source = "share/man/man1/*.1"

--- a/packages/node.toml
+++ b/packages/node.toml
@@ -133,3 +133,27 @@ path = "npx.cmd"
 [[artifacts.binaries]]
 name = "corepack"
 path = "corepack.cmd"
+
+[[integrations]]
+kind = "man_page"
+platforms = ["linux", "macos"]
+section = "1"
+source = "share/man/man1/*.1"
+
+[[integrations]]
+kind = "man_page"
+platforms = ["linux", "macos"]
+section = "1"
+source = "lib/node_modules/npm/man/man1/*.1"
+
+[[integrations]]
+kind = "man_page"
+platforms = ["linux", "macos"]
+section = "5"
+source = "lib/node_modules/npm/man/man5/*.5"
+
+[[integrations]]
+kind = "man_page"
+platforms = ["linux", "macos"]
+section = "7"
+source = "lib/node_modules/npm/man/man7/*.7"

--- a/packages/python.toml
+++ b/packages/python.toml
@@ -100,3 +100,9 @@ strip_components = 1
 [[artifacts.binaries]]
 name = "python"
 path = "python.exe"
+
+[[integrations]]
+kind = "man_page"
+platforms = ["linux", "macos"]
+section = "1"
+source = "share/man/man1/*.1"

--- a/releases/gh/2.92.0.toml
+++ b/releases/gh/2.92.0.toml
@@ -1,6 +1,11 @@
 name = "gh"
 version = "2.92.0"
 
+[[integrations]]
+kind = "man_page"
+platforms = ["linux", "macos"]
+section = "1"
+source = "share/man/man1/*.1"
 [[artifacts]]
 target = "x86_64-unknown-linux-gnu"
 url = "https://github.com/cli/cli/releases/download/v2.92.0/gh_2.92.0_linux_amd64.tar.gz"

--- a/releases/mise/2026.5.0.toml
+++ b/releases/mise/2026.5.0.toml
@@ -1,6 +1,11 @@
 name = "mise"
 version = "2026.5.0"
 
+[[integrations]]
+kind = "man_page"
+platforms = ["linux", "macos"]
+section = "1"
+source = "mise/man/man1/*.1"
 [[artifacts]]
 target = "x86_64-unknown-linux-gnu"
 url = "https://github.com/jdx/mise/releases/download/v2026.5.0/mise-v2026.5.0-linux-x64.tar.gz"

--- a/releases/neovim/0.12.2.toml
+++ b/releases/neovim/0.12.2.toml
@@ -1,6 +1,11 @@
 name = "neovim"
 version = "0.12.2"
 
+[[integrations]]
+kind = "man_page"
+platforms = ["linux", "macos"]
+section = "1"
+source = "share/man/man1/*.1"
 [[artifacts]]
 target = "x86_64-unknown-linux-gnu"
 url = "https://github.com/neovim/neovim/releases/download/v0.12.2/nvim-linux-x86_64.tar.gz"

--- a/releases/node/22.22.2.toml
+++ b/releases/node/22.22.2.toml
@@ -1,6 +1,29 @@
 name = "node"
 version = "22.22.2"
 
+[[integrations]]
+kind = "man_page"
+platforms = ["linux", "macos"]
+section = "1"
+source = "share/man/man1/*.1"
+
+[[integrations]]
+kind = "man_page"
+platforms = ["linux", "macos"]
+section = "1"
+source = "lib/node_modules/npm/man/man1/*.1"
+
+[[integrations]]
+kind = "man_page"
+platforms = ["linux", "macos"]
+section = "5"
+source = "lib/node_modules/npm/man/man5/*.5"
+
+[[integrations]]
+kind = "man_page"
+platforms = ["linux", "macos"]
+section = "7"
+source = "lib/node_modules/npm/man/man7/*.7"
 [[artifacts]]
 target = "x86_64-unknown-linux-gnu"
 url = "https://nodejs.org/dist/latest-v22.x/node-v22.22.2-linux-x64.tar.xz"

--- a/releases/python/3.14.4+20260414.toml
+++ b/releases/python/3.14.4+20260414.toml
@@ -1,6 +1,11 @@
 name = "python"
 version = "3.14.4+20260414"
 
+[[integrations]]
+kind = "man_page"
+platforms = ["linux", "macos"]
+section = "1"
+source = "share/man/man1/*.1"
 [[artifacts]]
 target = "x86_64-unknown-linux-gnu"
 url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260414/cpython-3.14.4%2B20260414-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"

--- a/scripts/registry-smoke-install.py
+++ b/scripts/registry-smoke-install.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import gzip
 import hashlib
 import platform
@@ -125,6 +126,15 @@ def integrations_from_manifest_or_package_template(path: Path, doc: dict) -> lis
 
     package_doc = tomllib.loads(package_template_path.read_text(encoding="utf-8"))
     return package_doc.get("integrations", [])
+
+
+def current_host_platform() -> str:
+    system = platform.system().lower()
+    if system == "darwin":
+        return "macos"
+    if system == "windows":
+        return "windows"
+    return "linux"
 
 
 DOWNLOAD_ATTEMPTS = 3
@@ -349,12 +359,39 @@ def smoke_manifest(
             )
 
         missing_integrations = []
+        host_platform = current_host_platform()
         for integration in integrations_from_manifest_or_package_template(path, doc):
+            platforms = integration.get("platforms", [])
+            if isinstance(platforms, list) and platforms and host_platform not in platforms:
+                continue
             source = integration.get("source")
             if not isinstance(source, str) or not source.strip():
                 continue
-            source_path = install_root / Path(source)
-            if not source_path.exists() or not source_path.is_file():
+            section = integration.get("section")
+            section_suffixes = []
+            if integration.get("kind") == "man_page" and isinstance(section, str):
+                section_suffixes = [f".{section}", f".{section}.gz"]
+            if any(ch in source for ch in "*?["):
+                matched = any(
+                    item.is_file()
+                    and fnmatch.fnmatch(item.relative_to(install_root).as_posix(), source)
+                    and (
+                        not section_suffixes
+                        or any(item.name.endswith(suffix) for suffix in section_suffixes)
+                    )
+                    for item in install_root.rglob("*")
+                )
+            else:
+                source_path = install_root / Path(source)
+                matched = (
+                    source_path.exists()
+                    and source_path.is_file()
+                    and (
+                        not section_suffixes
+                        or any(source_path.name.endswith(suffix) for suffix in section_suffixes)
+                    )
+                )
+            if not matched:
                 missing_integrations.append(source)
 
         if missing_integrations:

--- a/scripts/registry-validate-source.py
+++ b/scripts/registry-validate-source.py
@@ -27,7 +27,9 @@ RELEASE_KIND_VALUES = {
 VERSION_KIND_VALUES = {"asset_name_regex", "github_tag", "prefixed_semver_field", "regex_capture", "semver_field"}
 CHECKSUM_KIND_VALUES = {"asset_digest", "download_sha256", "download_index", "shasums256", "url_sha256"}
 ASSET_KIND_VALUES = {"json_index_asset", "release_asset_url", "templated"}
-INTEGRATION_KIND_VALUES = {"docker_cli_plugin", "path_plugin", "service"}
+INTEGRATION_KIND_VALUES = {"docker_cli_plugin", "man_page", "path_plugin", "service"}
+MAN_PAGE_SECTIONS = {str(section) for section in range(1, 10)}
+MAN_PAGE_PLATFORMS = {"linux", "macos", "windows"}
 SHELL_INIT_STRATEGY_VALUES = {"eval_stdout"}
 SHELL_INIT_FIELDS = ("bash", "zsh", "fish", "powershell")
 
@@ -89,13 +91,37 @@ def _validate_integrations(doc: dict) -> None:
         kind = _expect_non_empty_str(integration, "kind", prefix)
         if kind not in INTEGRATION_KIND_VALUES:
             raise ValidationError(f"{prefix}.kind must be a supported integration kind")
-        name = _expect_non_empty_str(integration, "name", prefix)
-        if kind in {"docker_cli_plugin", "path_plugin"}:
+        name = integration.get("name")
+        if kind != "man_page":
+            name = _expect_non_empty_str(integration, "name", prefix)
+        elif name is not None and (not isinstance(name, str) or not name.strip()):
+            raise ValidationError(f"{prefix}.name must be a non-empty string when present")
+        if kind in {"docker_cli_plugin", "man_page", "path_plugin"}:
             source = _expect_non_empty_str(integration, "source", prefix)
             _validate_integration_source(source, f"{prefix}.source")
+            if kind == "man_page":
+                section = _expect_non_empty_str(integration, "section", prefix)
+                if section not in MAN_PAGE_SECTIONS:
+                    raise ValidationError(f"{prefix}.section must be one of {', '.join(sorted(MAN_PAGE_SECTIONS))}")
+                platforms = integration.get("platforms", [])
+                if not isinstance(platforms, list) or not all(
+                    isinstance(platform, str) and platform in MAN_PAGE_PLATFORMS
+                    for platform in platforms
+                ):
+                    raise ValidationError(f"{prefix}.platforms must contain only {', '.join(sorted(MAN_PAGE_PLATFORMS))}")
+                if not (
+                    source.endswith(f".{section}")
+                    or source.endswith(f".{section}.gz")
+                    or source.endswith(f".*{section}")
+                    or source.endswith(f".*{section}.gz")
+                ):
+                    raise ValidationError(f"{prefix}.source must end with .{section} or .{section}.gz")
         if kind == "path_plugin":
             host = _expect_non_empty_str(integration, "host", prefix)
             key = f"{kind}:{host}:{name}"
+        elif kind == "man_page":
+            section = _expect_non_empty_str(integration, "section", prefix)
+            key = f"{kind}:{section}:{name or source}"
         else:
             key = f"{kind}:{name}"
         if kind == "service":

--- a/scripts/registry-validate.py
+++ b/scripts/registry-validate.py
@@ -23,8 +23,10 @@ RELEASE_KIND_VALUES = {
 VERSION_KIND_VALUES = {"asset_name_regex", "github_tag", "prefixed_semver_field", "regex_capture", "semver_field"}
 CHECKSUM_KIND_VALUES = {"asset_digest", "download_sha256", "download_index", "shasums256", "url_sha256"}
 ASSET_KIND_VALUES = {"json_index_asset", "release_asset_url", "templated"}
-INTEGRATION_KIND_VALUES = {"docker_cli_plugin", "path_plugin", "service"}
+INTEGRATION_KIND_VALUES = {"docker_cli_plugin", "man_page", "path_plugin", "service"}
 SERVICE_SOURCE_FIELDS = {"source", "linux_systemd_user", "macos_launch_agent", "windows_service"}
+MAN_PAGE_SECTIONS = {str(section) for section in range(1, 10)}
+MAN_PAGE_PLATFORMS = {"linux", "macos", "windows"}
 
 
 def err(errors: list[str], path: Path, message: str) -> None:
@@ -120,9 +122,29 @@ def validate_integrations(path: Path, doc: dict, errors: list[str]) -> None:
                 err(errors, path, f"{prefix}.source must be a non-empty string")
             elif not is_safe_relative_source_path(source):
                 err(errors, path, f"{prefix}.source must be a normalized relative path")
+            elif kind == "man_page":
+                section = integration.get("section")
+                if not isinstance(section, str) or section not in MAN_PAGE_SECTIONS:
+                    err(errors, path, f"{prefix}.section must be one of {', '.join(sorted(MAN_PAGE_SECTIONS))}")
+                platforms = integration.get("platforms", [])
+                if not isinstance(platforms, list) or not all(
+                    isinstance(platform, str) and platform in MAN_PAGE_PLATFORMS
+                    for platform in platforms
+                ):
+                    err(errors, path, f"{prefix}.platforms must contain only {', '.join(sorted(MAN_PAGE_PLATFORMS))}")
+                elif not (
+                    source.endswith(f".{section}")
+                    or source.endswith(f".{section}.gz")
+                    or source.endswith(f".*{section}")
+                    or source.endswith(f".*{section}.gz")
+                ):
+                    err(errors, path, f"{prefix}.source must end with .{section} or .{section}.gz")
         name = integration.get("name")
-        if not isinstance(name, str) or not name.strip():
+        if kind != "man_page" and (not isinstance(name, str) or not name.strip()):
             err(errors, path, f"{prefix}.name must be a non-empty string")
+            continue
+        if kind == "man_page" and name is not None and (not isinstance(name, str) or not name.strip()):
+            err(errors, path, f"{prefix}.name must be a non-empty string when present")
             continue
         if kind == "path_plugin":
             host = integration.get("host")
@@ -130,6 +152,11 @@ def validate_integrations(path: Path, doc: dict, errors: list[str]) -> None:
                 err(errors, path, f"{prefix}.host must be a non-empty string")
                 continue
             key = f"{kind}:{host}:{name}"
+        elif kind == "man_page":
+            section = integration.get("section")
+            if not isinstance(section, str) or section not in MAN_PAGE_SECTIONS:
+                continue
+            key = f"{kind}:{section}:{name or integration.get('source')}"
         else:
             key = f"{kind}:{name}"
         if kind == "service":


### PR DESCRIPTION
## Summary
- add compact Linux/macOS-scoped man_page glob entries for gh, mise, neovim, node, and python package templates
- update current release manifests so existing latest installs expose those manpages on supported hosts
- teach registry validators and smoke-install checks to accept man_page globs, platforms, and section-aware matching
- fix mise binary paths to match the packaged archive layout

## Validation
- python3 scripts/registry-validate-source.py packages/*.toml
- python3 scripts/registry-validate.py --allow-missing-signatures packages/gh.toml packages/mise.toml packages/neovim.toml packages/node.toml packages/python.toml releases/gh/2.92.0.toml releases/mise/2026.5.0.toml releases/neovim/0.12.2.toml releases/node/22.22.2.toml releases/python/3.14.4+20260414.toml
- python3 scripts/registry-smoke-install.py releases/gh/2.92.0.toml releases/mise/2026.5.0.toml releases/neovim/0.12.2.toml releases/node/22.22.2.toml releases/python/3.14.4+20260414.toml
- python3 -m py_compile scripts/registry-validate.py scripts/registry-validate-source.py scripts/registry-smoke-install.py
- cargo test -p crosspack-registry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for manual page (man page) integrations, enabling improved package documentation access.
  * Multiple packages now expose their manual pages for Linux and macOS platforms.
  * Enhanced installation process with wildcard pattern matching for integration sources.

* **Documentation**
  * Updated documentation to describe man page integration configuration and requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->