### PR TITLE
feat: add boundary test packages

### DIFF
--- a/.github/workflows/registry-quality-gate.yml
+++ b/.github/workflows/registry-quality-gate.yml
@@ -153,3 +153,45 @@ jobs:
       - name: App-bundle smoke canary (macOS)
         if: runner.os == 'macOS'
         run: python3 ./scripts/registry-smoke-install.py --app-bundle-canary
+
+  pr-crosspack-native:
+    name: PR Crosspack Native Validation
+    if: github.event_name == 'pull_request'
+    needs:
+      - detect-pr-manifests
+      - preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout registry
+        uses: actions/checkout@v4
+        with:
+          path: registry
+          fetch-depth: 0
+
+      - name: Checkout Crosspack
+        uses: actions/checkout@v4
+        with:
+          repository: spiritledsoftware/crosspack
+          submodules: false
+          path: crosspack
+
+      - name: Crosspack native validation (changed packages)
+        if: needs.detect-pr-manifests.outputs.manifest_count != '0'
+        shell: bash
+        env:
+          MANIFESTS_JSON: ${{ needs.detect-pr-manifests.outputs.manifests_json }}
+          CROSSPACK_REPO_ROOT: ${{ github.workspace }}/crosspack
+          CROSSPACK_NATIVE_TARGETS: x86_64-unknown-linux-gnu x86_64-pc-windows-msvc
+        run: |
+          cd registry
+          mapfile -t manifests < <(
+            MANIFESTS_JSON="$MANIFESTS_JSON" python3 -c 'import json, os; print("\n".join(json.loads(os.environ["MANIFESTS_JSON"])))'
+          )
+          ./scripts/registry-crosspack-native-check.sh "${manifests[@]}"
+
+      - name: Skip Crosspack native validation (none changed)
+        if: needs.detect-pr-manifests.outputs.manifest_count == '0'
+        shell: bash
+        run: echo "No changed manifests in this PR."

--- a/packages/clang.toml
+++ b/packages/clang.toml
@@ -1,0 +1,130 @@
+name = "clang"
+license = "Apache-2.0 WITH LLVM-exception"
+homepage = "https://xpack.github.io/dev-tools/clang/"
+provides = ["c-compiler", "cxx-compiler", "llvm"]
+
+[source.release]
+kind = "github_releases"
+repo = "xpack-dev-tools/clang-xpack"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "url_sha256"
+url_template = "{url}.sha"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "xpack-clang-{version}-linux-x64.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "clang"
+path = "bin/clang"
+[[artifacts.binaries]]
+name = "clang++"
+path = "bin/clang++"
+[[artifacts.binaries]]
+name = "lld"
+path = "bin/lld"
+[[artifacts.binaries]]
+name = "llvm-ar"
+path = "bin/llvm-ar"
+[[artifacts.binaries]]
+name = "llvm-ranlib"
+path = "bin/llvm-ranlib"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "xpack-clang-{version}-linux-arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "clang"
+path = "bin/clang"
+[[artifacts.binaries]]
+name = "clang++"
+path = "bin/clang++"
+[[artifacts.binaries]]
+name = "lld"
+path = "bin/lld"
+[[artifacts.binaries]]
+name = "llvm-ar"
+path = "bin/llvm-ar"
+[[artifacts.binaries]]
+name = "llvm-ranlib"
+path = "bin/llvm-ranlib"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "xpack-clang-{version}-darwin-x64.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "clang"
+path = "bin/clang"
+[[artifacts.binaries]]
+name = "clang++"
+path = "bin/clang++"
+[[artifacts.binaries]]
+name = "lld"
+path = "bin/lld"
+[[artifacts.binaries]]
+name = "llvm-ar"
+path = "bin/llvm-ar"
+[[artifacts.binaries]]
+name = "llvm-ranlib"
+path = "bin/llvm-ranlib"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "xpack-clang-{version}-darwin-arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "clang"
+path = "bin/clang"
+[[artifacts.binaries]]
+name = "clang++"
+path = "bin/clang++"
+[[artifacts.binaries]]
+name = "lld"
+path = "bin/lld"
+[[artifacts.binaries]]
+name = "llvm-ar"
+path = "bin/llvm-ar"
+[[artifacts.binaries]]
+name = "llvm-ranlib"
+path = "bin/llvm-ranlib"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "xpack-clang-{version}-win32-x64.zip"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "clang"
+path = "bin/clang.exe"
+[[artifacts.binaries]]
+name = "clang++"
+path = "bin/clang++.exe"
+[[artifacts.binaries]]
+name = "lld"
+path = "bin/lld.exe"
+[[artifacts.binaries]]
+name = "llvm-ar"
+path = "bin/llvm-ar.exe"
+[[artifacts.binaries]]
+name = "llvm-ranlib"
+path = "bin/llvm-ranlib.exe"

--- a/packages/cmake.toml
+++ b/packages/cmake.toml
@@ -1,0 +1,114 @@
+name = "cmake"
+license = "BSD-3-Clause"
+homepage = "https://github.com/Kitware/CMake"
+
+[source.release]
+kind = "github_releases"
+repo = "Kitware/CMake"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "asset_digest"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "cmake-{version}-linux-x86_64.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "cmake"
+path = "bin/cmake"
+[[artifacts.binaries]]
+name = "ctest"
+path = "bin/ctest"
+[[artifacts.binaries]]
+name = "cpack"
+path = "bin/cpack"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "cmake-{version}-linux-aarch64.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "cmake"
+path = "bin/cmake"
+[[artifacts.binaries]]
+name = "ctest"
+path = "bin/ctest"
+[[artifacts.binaries]]
+name = "cpack"
+path = "bin/cpack"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "cmake-{version}-macos-universal.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "cmake"
+path = "bin/cmake"
+[[artifacts.binaries]]
+name = "ctest"
+path = "bin/ctest"
+[[artifacts.binaries]]
+name = "cpack"
+path = "bin/cpack"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "cmake-{version}-macos-universal.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "cmake"
+path = "bin/cmake"
+[[artifacts.binaries]]
+name = "ctest"
+path = "bin/ctest"
+[[artifacts.binaries]]
+name = "cpack"
+path = "bin/cpack"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "cmake-{version}-windows-x86_64.zip"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "cmake"
+path = "bin/cmake.exe"
+[[artifacts.binaries]]
+name = "ctest"
+path = "bin/ctest.exe"
+[[artifacts.binaries]]
+name = "cpack"
+path = "bin/cpack.exe"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "cmake-{version}-windows-arm64.zip"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "cmake"
+path = "bin/cmake.exe"
+[[artifacts.binaries]]
+name = "ctest"
+path = "bin/ctest.exe"
+[[artifacts.binaries]]
+name = "cpack"
+path = "bin/cpack.exe"

--- a/packages/fish.toml
+++ b/packages/fish.toml
@@ -1,0 +1,37 @@
+name = "fish"
+license = "GPL-2.0-only"
+homepage = "https://github.com/fish-shell/fish-shell"
+
+[source.release]
+kind = "github_releases"
+repo = "fish-shell/fish-shell"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "asset_digest"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "fish-{version}-linux-x86_64.tar.xz"
+archive = "tar.xz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "fish"
+path = "fish"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "fish-{version}-linux-aarch64.tar.xz"
+archive = "tar.xz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "fish"
+path = "fish"

--- a/packages/gcc.toml
+++ b/packages/gcc.toml
@@ -1,0 +1,68 @@
+name = "gcc"
+license = "GPL-3.0-or-later WITH GCC-exception-3.1"
+homepage = "https://xpack.github.io/dev-tools/gcc/"
+provides = ["c-compiler", "cxx-compiler"]
+
+[source.release]
+kind = "github_releases"
+repo = "xpack-dev-tools/gcc-xpack"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "url_sha256"
+url_template = "{url}.sha"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "xpack-gcc-{version}-linux-x64.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "gcc"
+path = "bin/gcc"
+[[artifacts.binaries]]
+name = "g++"
+path = "bin/g++"
+[[artifacts.binaries]]
+name = "cpp"
+path = "bin/cpp"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "xpack-gcc-{version}-linux-arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "gcc"
+path = "bin/gcc"
+[[artifacts.binaries]]
+name = "g++"
+path = "bin/g++"
+[[artifacts.binaries]]
+name = "cpp"
+path = "bin/cpp"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "xpack-gcc-{version}-win32-x64.zip"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "gcc"
+path = "bin/gcc.exe"
+[[artifacts.binaries]]
+name = "g++"
+path = "bin/g++.exe"
+[[artifacts.binaries]]
+name = "cpp"
+path = "bin/cpp.exe"

--- a/packages/ninja.toml
+++ b/packages/ninja.toml
@@ -1,0 +1,78 @@
+name = "ninja"
+license = "Apache-2.0"
+homepage = "https://github.com/ninja-build/ninja"
+
+[source.release]
+kind = "github_releases"
+repo = "ninja-build/ninja"
+tag_prefix = "v"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "asset_digest"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "ninja-linux.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "ninja"
+path = "ninja"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "ninja-linux-aarch64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "ninja"
+path = "ninja"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "ninja-mac.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "ninja"
+path = "ninja"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "ninja-mac.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "ninja"
+path = "ninja"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "ninja-win.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "ninja"
+path = "ninja.exe"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "ninja-winarm64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "ninja"
+path = "ninja.exe"

--- a/packages/nushell.toml
+++ b/packages/nushell.toml
@@ -1,0 +1,77 @@
+name = "nushell"
+license = "MIT"
+homepage = "https://github.com/nushell/nushell"
+
+[source.release]
+kind = "github_releases"
+repo = "nushell/nushell"
+include_prereleases = false
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "asset_digest"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "nu-{version}-x86_64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "nu"
+path = "nu"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "nu-{version}-aarch64-unknown-linux-gnu.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "nu"
+path = "nu"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "nu-{version}-x86_64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "nu"
+path = "nu"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "nu-{version}-aarch64-apple-darwin.tar.gz"
+archive = "tar.gz"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "nu"
+path = "nu"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "nu-{version}-x86_64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "nu"
+path = "nu.exe"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "nu-{version}-aarch64-pc-windows-msvc.zip"
+archive = "zip"
+strip_components = 1
+
+[[artifacts.binaries]]
+name = "nu"
+path = "nu.exe"

--- a/packages/powershell.toml
+++ b/packages/powershell.toml
@@ -1,0 +1,78 @@
+name = "powershell"
+license = "MIT"
+homepage = "https://github.com/PowerShell/PowerShell"
+
+[source.release]
+kind = "github_releases"
+repo = "PowerShell/PowerShell"
+include_prereleases = false
+tag_prefix = "v"
+
+[source.version]
+kind = "github_tag"
+
+[source.checksum]
+kind = "asset_digest"
+
+[source.asset]
+kind = "release_asset_url"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+asset = "powershell-{version}-linux-x64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "pwsh"
+path = "pwsh"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+asset = "powershell-{version}-linux-arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "pwsh"
+path = "pwsh"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+asset = "powershell-{version}-osx-x64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "pwsh"
+path = "pwsh"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+asset = "powershell-{version}-osx-arm64.tar.gz"
+archive = "tar.gz"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "pwsh"
+path = "pwsh"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+asset = "PowerShell-{version}-win-x64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "pwsh"
+path = "pwsh.exe"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+asset = "PowerShell-{version}-win-arm64.zip"
+archive = "zip"
+strip_components = 0
+
+[[artifacts.binaries]]
+name = "pwsh"
+path = "pwsh.exe"

--- a/releases/clang/21.1.8-1.toml
+++ b/releases/clang/21.1.8-1.toml
@@ -1,0 +1,27 @@
+name = "clang"
+version = "21.1.8-1"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/xpack-dev-tools/clang-xpack/releases/download/v21.1.8-1/xpack-clang-21.1.8-1-linux-x64.tar.gz"
+sha256 = "0db58136aedb58b9af8c605a1b1570defbe06618f82bff60d24d3327f81d8321"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/xpack-dev-tools/clang-xpack/releases/download/v21.1.8-1/xpack-clang-21.1.8-1-linux-arm64.tar.gz"
+sha256 = "be1eae2706c049ff9d1c5816e58bb5557d75810c9762cb929208472f7914617e"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/xpack-dev-tools/clang-xpack/releases/download/v21.1.8-1/xpack-clang-21.1.8-1-darwin-x64.tar.gz"
+sha256 = "eab22258684105f5c32bb29772e2b17bc2ec4eac49b3c4d1775e45b3d1baf385"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/xpack-dev-tools/clang-xpack/releases/download/v21.1.8-1/xpack-clang-21.1.8-1-darwin-arm64.tar.gz"
+sha256 = "562270fc3029fbec56cadde80223efe2ea33e9fde46954582447afb4832310ea"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/xpack-dev-tools/clang-xpack/releases/download/v21.1.8-1/xpack-clang-21.1.8-1-win32-x64.zip"
+sha256 = "b23d38e2c1c539182919e147e7158fd8b4e8bdd9e6ddc5dfe06f6488c6d9d516"

--- a/releases/cmake/4.3.2.toml
+++ b/releases/cmake/4.3.2.toml
@@ -1,0 +1,32 @@
+name = "cmake"
+version = "4.3.2"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/Kitware/CMake/releases/download/v4.3.2/cmake-4.3.2-linux-x86_64.tar.gz"
+sha256 = "791ae3604841ca03cb3889a3ad89165346e4b180ae3448efd4b0caa9ef46d245"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/Kitware/CMake/releases/download/v4.3.2/cmake-4.3.2-linux-aarch64.tar.gz"
+sha256 = "377079ab739f5765176f427609d9a2015b756ea20d5cba908d279c3731a2f481"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/Kitware/CMake/releases/download/v4.3.2/cmake-4.3.2-macos-universal.tar.gz"
+sha256 = "808ab43a0db04c8eec9ed7db12b90d7be1c8e2e75f4a060724d604a2043ccaf7"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/Kitware/CMake/releases/download/v4.3.2/cmake-4.3.2-macos-universal.tar.gz"
+sha256 = "808ab43a0db04c8eec9ed7db12b90d7be1c8e2e75f4a060724d604a2043ccaf7"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/Kitware/CMake/releases/download/v4.3.2/cmake-4.3.2-windows-x86_64.zip"
+sha256 = "83d20c23f5c5f64b3b328785e35b23c532e33057a97ed6294acaca3781b78a01"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+url = "https://github.com/Kitware/CMake/releases/download/v4.3.2/cmake-4.3.2-windows-arm64.zip"
+sha256 = "42a2a88fc57e70d04a92f6eaaac2094241995f53584bc2afdae7e6ef982b3781"

--- a/releases/fish/4.7.0.toml
+++ b/releases/fish/4.7.0.toml
@@ -1,0 +1,12 @@
+name = "fish"
+version = "4.7.0"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/fish-shell/fish-shell/releases/download/4.7.0/fish-4.7.0-linux-x86_64.tar.xz"
+sha256 = "5a3e4551f8aca94d829727f74001823f2035551a9a36345142bef0f64205d62e"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/fish-shell/fish-shell/releases/download/4.7.0/fish-4.7.0-linux-aarch64.tar.xz"
+sha256 = "6e6e89aa42bfa09160a97ff68c242b3c0e109d12bc62d5a3802298b3653c3602"

--- a/releases/gcc/15.2.0-1.toml
+++ b/releases/gcc/15.2.0-1.toml
@@ -1,0 +1,17 @@
+name = "gcc"
+version = "15.2.0-1"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/xpack-dev-tools/gcc-xpack/releases/download/v15.2.0-1/xpack-gcc-15.2.0-1-linux-x64.tar.gz"
+sha256 = "f6dcc3815299a23b2b4372223c4ca5f1b5a0543ed097d57eb67e0753b7c484e0"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/xpack-dev-tools/gcc-xpack/releases/download/v15.2.0-1/xpack-gcc-15.2.0-1-linux-arm64.tar.gz"
+sha256 = "8d6e78782994ffdfdabbc8f485bc98d817d17b1f9c12e4163c7d6c50d4a16912"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/xpack-dev-tools/gcc-xpack/releases/download/v15.2.0-1/xpack-gcc-15.2.0-1-win32-x64.zip"
+sha256 = "be18e491c8da564f0b923d29ca0ffc8927f4a51c883d5827a8eb9c3d5386c5b0"

--- a/releases/ninja/1.13.2.toml
+++ b/releases/ninja/1.13.2.toml
@@ -1,0 +1,32 @@
+name = "ninja"
+version = "1.13.2"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/ninja-build/ninja/releases/download/v1.13.2/ninja-linux.zip"
+sha256 = "5749cbc4e668273514150a80e387a957f933c6ed3f5f11e03fb30955e2bbead6"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/ninja-build/ninja/releases/download/v1.13.2/ninja-linux-aarch64.zip"
+sha256 = "fd2cacc8050a7f12a16a2e48f9e06fca5c14fc4c2bee2babb67b58be17a607fc"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/ninja-build/ninja/releases/download/v1.13.2/ninja-mac.zip"
+sha256 = "c99048673aa765960a99cf10c6ddb9f1fad506099ff0a0e137ad8960a88f321b"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/ninja-build/ninja/releases/download/v1.13.2/ninja-mac.zip"
+sha256 = "c99048673aa765960a99cf10c6ddb9f1fad506099ff0a0e137ad8960a88f321b"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/ninja-build/ninja/releases/download/v1.13.2/ninja-win.zip"
+sha256 = "07fc8261b42b20e71d1720b39068c2e14ffcee6396b76fb7a795fb460b78dc65"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+url = "https://github.com/ninja-build/ninja/releases/download/v1.13.2/ninja-winarm64.zip"
+sha256 = "e52f0bdef9dfb1003229dbd6508a508c4073fd017247002adc66e5e806cb0391"

--- a/releases/nushell/0.112.2.toml
+++ b/releases/nushell/0.112.2.toml
@@ -1,0 +1,32 @@
+name = "nushell"
+version = "0.112.2"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/nushell/nushell/releases/download/0.112.2/nu-0.112.2-x86_64-unknown-linux-gnu.tar.gz"
+sha256 = "4038c171dd2618f2413a2aa615b8dab7e9d04852be8200f1755df3e422328395"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/nushell/nushell/releases/download/0.112.2/nu-0.112.2-aarch64-unknown-linux-gnu.tar.gz"
+sha256 = "c25a713f4c10bd886162c62c278db6cf8a657754be53d33379af70fbadab07b8"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/nushell/nushell/releases/download/0.112.2/nu-0.112.2-x86_64-apple-darwin.tar.gz"
+sha256 = "8de1dc4a918a1af29fce75d263a8f673f16d35c04ebaa5e3c3ac4ce1eb154f3f"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/nushell/nushell/releases/download/0.112.2/nu-0.112.2-aarch64-apple-darwin.tar.gz"
+sha256 = "a61806761db7bc2eddfc313d5ec496c92776a37124bc64a3036374bd55e8c881"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/nushell/nushell/releases/download/0.112.2/nu-0.112.2-x86_64-pc-windows-msvc.zip"
+sha256 = "db57750ec878365135e7baebee9f5ec74b84c80158ed0168f1ccbe15d6ec251d"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+url = "https://github.com/nushell/nushell/releases/download/0.112.2/nu-0.112.2-aarch64-pc-windows-msvc.zip"
+sha256 = "badc7536bf502b3d46c5abf6dc84d394641f407617e6be99cc8346fe946c5550"

--- a/releases/powershell/7.6.1.toml
+++ b/releases/powershell/7.6.1.toml
@@ -1,0 +1,32 @@
+name = "powershell"
+version = "7.6.1"
+
+[[artifacts]]
+target = "x86_64-unknown-linux-gnu"
+url = "https://github.com/PowerShell/PowerShell/releases/download/v7.6.1/powershell-7.6.1-linux-x64.tar.gz"
+sha256 = "dfc94229767921603f7c3e1cb1ac5aa931448af7496ccf657723b6278057c415"
+
+[[artifacts]]
+target = "aarch64-unknown-linux-gnu"
+url = "https://github.com/PowerShell/PowerShell/releases/download/v7.6.1/powershell-7.6.1-linux-arm64.tar.gz"
+sha256 = "73498813194ea0d849d5942332ee6e51657ea66da08216aa1050788d5c52b741"
+
+[[artifacts]]
+target = "x86_64-apple-darwin"
+url = "https://github.com/PowerShell/PowerShell/releases/download/v7.6.1/powershell-7.6.1-osx-x64.tar.gz"
+sha256 = "b5f874a832bec2ba78cd3e44fdbcb04c1b6144d9eab42b9881cb8b9400bcc504"
+
+[[artifacts]]
+target = "aarch64-apple-darwin"
+url = "https://github.com/PowerShell/PowerShell/releases/download/v7.6.1/powershell-7.6.1-osx-arm64.tar.gz"
+sha256 = "9e1078f70b11c40e10f4bad1354db1cdcaf38cd6775fcf40e0738e3f5ac6807e"
+
+[[artifacts]]
+target = "x86_64-pc-windows-msvc"
+url = "https://github.com/PowerShell/PowerShell/releases/download/v7.6.1/PowerShell-7.6.1-win-x64.zip"
+sha256 = "b5c9e8457ca7df4998abe3cc2c58e6dd4005ad1b4c5320bbac86244a747db91d"
+
+[[artifacts]]
+target = "aarch64-pc-windows-msvc"
+url = "https://github.com/PowerShell/PowerShell/releases/download/v7.6.1/PowerShell-7.6.1-win-arm64.zip"
+sha256 = "f8976558a687dd610eec33a42868a090f611f3bfbc0ae69c2bc5d986e3b53847"

--- a/scripts/registry-crosspack-native-check.sh
+++ b/scripts/registry-crosspack-native-check.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+crosspack_root="${CROSSPACK_REPO_ROOT:-}"
+if [[ -z "$crosspack_root" ]]; then
+  if [[ -f "$repo_root/../Cargo.toml" && -d "$repo_root/../crates/crosspack-cli" ]]; then
+    crosspack_root="$(cd "$repo_root/.." && pwd)"
+  else
+    echo "CROSSPACK_REPO_ROOT is required when the registry is not checked out inside Crosspack" >&2
+    exit 1
+  fi
+fi
+
+if [[ ! -f "$crosspack_root/Cargo.toml" || ! -d "$crosspack_root/crates/crosspack-cli" ]]; then
+  echo "CROSSPACK_REPO_ROOT does not point at a Crosspack checkout: $crosspack_root" >&2
+  exit 1
+fi
+
+if [[ "$#" -gt 0 ]]; then
+  changed_manifests=("$@")
+else
+  mapfile -t changed_manifests < <(./scripts/registry-changed-manifests.sh)
+fi
+
+manifests_json="$(
+  printf '%s\n' "${changed_manifests[@]}" \
+    | python3 -c 'import json, sys; print(json.dumps([line.strip() for line in sys.stdin if line.strip()]))'
+)"
+
+mapfile -t package_names < <(
+  MANIFESTS_JSON="$manifests_json" python3 - <<'PY'
+import json
+import os
+import sys
+
+names = set()
+for raw in json.loads(os.environ["MANIFESTS_JSON"]):
+    path = raw.strip()
+    if path.startswith("packages/") and path.endswith(".toml"):
+        names.add(path.removeprefix("packages/").removesuffix(".toml"))
+    elif path.startswith("releases/") and path.endswith(".toml"):
+        parts = path.split("/")
+        if len(parts) >= 3:
+            names.add(parts[1])
+
+for name in sorted(names):
+    print(name)
+PY
+)
+
+if [[ "${#package_names[@]}" -eq 0 ]]; then
+  echo "No changed package or release manifests require Crosspack native validation."
+  exit 0
+fi
+
+for tool in openssl python3 cargo; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "$tool is required" >&2
+    exit 1
+  fi
+done
+
+temp_registry="$(mktemp -d)"
+temp_prefix="$(mktemp -d)"
+key_file="$temp_registry/test-registry-signing.pem"
+trap 'rm -rf "$temp_registry" "$temp_prefix"' EXIT
+
+cp -a "$repo_root/." "$temp_registry/"
+openssl genpkey -algorithm ed25519 -out "$key_file" >/dev/null 2>&1
+openssl pkey -in "$key_file" -pubout -outform DER 2>/dev/null \
+  | python3 -c 'import sys; data = sys.stdin.buffer.read(); print(data[-32:].hex())' \
+  > "$temp_registry/registry.pub"
+
+while IFS= read -r -d '' manifest; do
+  sig_bin="$(mktemp)"
+  openssl pkeyutl -sign -rawin -inkey "$key_file" -in "$manifest" -out "$sig_bin"
+  python3 - "$sig_bin" "$manifest.sig" <<'PY'
+from pathlib import Path
+import sys
+
+Path(sys.argv[2]).write_text(
+    Path(sys.argv[1]).read_bytes().hex() + "\n",
+    encoding="utf-8",
+)
+PY
+  rm -f "$sig_bin"
+done < <(find "$temp_registry/packages" "$temp_registry/releases" -type f -name '*.toml' -print0)
+
+targets=()
+if [[ -n "${CROSSPACK_NATIVE_TARGETS:-}" ]]; then
+  read -r -a targets <<< "$CROSSPACK_NATIVE_TARGETS"
+fi
+
+run_crosspack() {
+  CROSSPACK_PREFIX="$temp_prefix" cargo run -q -p crosspack-cli --bin crosspack \
+    --manifest-path "$crosspack_root/Cargo.toml" \
+    -- --registry-root "$temp_registry" "$@"
+}
+
+for package_name in "${package_names[@]}"; do
+  echo "crosspack info $package_name"
+  run_crosspack info "$package_name" >/dev/null
+
+  if [[ "${#targets[@]}" -eq 0 ]]; then
+    echo "crosspack install --dry-run $package_name"
+    run_crosspack install --dry-run --non-interactive "$package_name" >/dev/null
+  else
+    for target in "${targets[@]}"; do
+      if ! python3 - "$temp_registry/packages/$package_name.toml" "$target" <<'PY'
+import sys
+import tomllib
+from pathlib import Path
+
+path = Path(sys.argv[1])
+target = sys.argv[2]
+doc = tomllib.loads(path.read_text(encoding="utf-8"))
+if any(artifact.get("target") == target for artifact in doc.get("artifacts", [])):
+    raise SystemExit(0)
+raise SystemExit(1)
+PY
+      then
+        echo "skip $package_name for unavailable target $target"
+        continue
+      fi
+      echo "crosspack install --dry-run --target $target $package_name"
+      run_crosspack install --dry-run --non-interactive --target "$target" "$package_name" >/dev/null
+    done
+  fi
+done
+
+echo "Crosspack native registry validation passed for ${#package_names[@]} package(s)."

--- a/scripts/registry-crosspack-native-check.sh
+++ b/scripts/registry-crosspack-native-check.sh
@@ -19,6 +19,23 @@ if [[ ! -f "$crosspack_root/Cargo.toml" || ! -d "$crosspack_root/crates/crosspac
   exit 1
 fi
 
+for tool in openssl python3 cargo; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "$tool is required" >&2
+    exit 1
+  fi
+done
+
+python3 - <<'PY'
+import sys
+
+if sys.version_info < (3, 11):
+    raise SystemExit(
+        "python3 3.11+ is required for registry native validation "
+        f"(found {sys.version_info.major}.{sys.version_info.minor})"
+    )
+PY
+
 if [[ "$#" -gt 0 ]]; then
   changed_manifests=("$@")
 else
@@ -55,13 +72,6 @@ if [[ "${#package_names[@]}" -eq 0 ]]; then
   echo "No changed package or release manifests require Crosspack native validation."
   exit 0
 fi
-
-for tool in openssl python3 cargo; do
-  if ! command -v "$tool" >/dev/null 2>&1; then
-    echo "$tool is required" >&2
-    exit 1
-  fi
-done
 
 temp_registry="$(mktemp -d)"
 temp_prefix="$(mktemp -d)"

--- a/scripts/registry-generate-manifest.py
+++ b/scripts/registry-generate-manifest.py
@@ -65,8 +65,12 @@ def _render_package_policy(chunks: list[str], doc: dict) -> None:
         chunks.append(_line("provides", doc["provides"]))
         chunks.append("")
     for key in ("conflicts", "replaces"):
-        value = doc.get(key)
-        if isinstance(value, dict) and value:
+        if key not in doc:
+            continue
+        value = doc[key]
+        if not isinstance(value, dict):
+            raise GenerateError(f"package policy field {key} must be a table")
+        if value:
             _render_table(chunks, f"[{key}]", value)
 
 

--- a/scripts/registry-generate-manifest.py
+++ b/scripts/registry-generate-manifest.py
@@ -60,6 +60,16 @@ def _render_table(chunks: list[str], header: str, table: dict) -> None:
     chunks.append("")
 
 
+def _render_package_policy(chunks: list[str], doc: dict) -> None:
+    if "provides" in doc:
+        chunks.append(_line("provides", doc["provides"]))
+        chunks.append("")
+    for key in ("conflicts", "replaces"):
+        value = doc.get(key)
+        if isinstance(value, dict) and value:
+            _render_table(chunks, f"[{key}]", value)
+
+
 def _render_artifact_templates(chunks: list[str], artifacts: list[dict]) -> None:
     for artifact in artifacts:
         chunks.append("[[artifacts]]")
@@ -107,6 +117,8 @@ def render_package_text(doc: dict) -> str:
     chunks.append(_line("license", doc["license"]))
     chunks.append(_line("homepage", doc["homepage"]))
     chunks.append("")
+
+    _render_package_policy(chunks, doc)
 
     source = doc.get("source")
     if isinstance(source, dict):

--- a/scripts/registry-smoke-install.py
+++ b/scripts/registry-smoke-install.py
@@ -176,11 +176,31 @@ def strip_name(name: str, strip_components: int) -> str | None:
     return str(PurePosixPath(*parts[strip_components:]))
 
 
+def clone_tar_member(member: tarfile.TarInfo) -> tarfile.TarInfo:
+    clone = tarfile.TarInfo(member.name)
+    for attr in (
+        "type",
+        "linkname",
+        "size",
+        "mode",
+        "mtime",
+        "uid",
+        "gid",
+        "uname",
+        "gname",
+        "devmajor",
+        "devminor",
+    ):
+        setattr(clone, attr, getattr(member, attr))
+    clone.pax_headers = dict(member.pax_headers)
+    return clone
+
+
 def stripped_tar_member(member: tarfile.TarInfo, strip_components: int) -> tarfile.TarInfo | None:
     stripped = strip_name(member.name, strip_components)
     if not stripped:
         return None
-    clone = member.replace(deep=False)
+    clone = clone_tar_member(member)
     clone.name = stripped
     if clone.linkname:
         stripped_link = strip_name(clone.linkname, strip_components)

--- a/scripts/registry-smoke-install.py
+++ b/scripts/registry-smoke-install.py
@@ -176,6 +176,59 @@ def strip_name(name: str, strip_components: int) -> str | None:
     return str(PurePosixPath(*parts[strip_components:]))
 
 
+def stripped_tar_member(member: tarfile.TarInfo, strip_components: int) -> tarfile.TarInfo | None:
+    stripped = strip_name(member.name, strip_components)
+    if not stripped:
+        return None
+    clone = member.replace(deep=False)
+    clone.name = stripped
+    if clone.linkname:
+        stripped_link = strip_name(clone.linkname, strip_components)
+        if stripped_link:
+            clone.linkname = stripped_link
+        else:
+            link_parts = PurePosixPath(clone.linkname).parts
+            if not link_parts or link_parts[0] == "/" or ".." in link_parts:
+                return None
+    return clone
+
+
+def extract_tar_member_file(
+    tf: tarfile.TarFile,
+    member: tarfile.TarInfo,
+    target: Path,
+) -> None:
+    source = tf.extractfile(member)
+    if source is None:
+        return
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with source, target.open("wb") as out:
+        shutil.copyfileobj(source, out)
+    target.chmod(member.mode or target.stat().st_mode)
+
+
+def tar_link_target(root: Path, target: Path, linkname: str) -> Path:
+    if "/" in linkname:
+        return root / linkname
+    return target.parent / linkname
+
+
+def materialize_tar_link(
+    root: Path, target: Path, linkname: str, *, symlink: bool
+) -> bool:
+    if target.exists() or target.is_symlink():
+        return True
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if symlink:
+        target.symlink_to(linkname)
+    else:
+        link_target = tar_link_target(root, target, linkname)
+        if not link_target.exists():
+            return False
+        target.hardlink_to(link_target)
+    return True
+
+
 def extract_archive(src: Path, dest: Path, archive: str, strip_components: int) -> None:
     if archive in {"tar.gz", "tgz", "tar.xz"}:
         if archive in {"tar.gz", "tgz"}:
@@ -183,26 +236,27 @@ def extract_archive(src: Path, dest: Path, archive: str, strip_components: int) 
         else:
             mode = "r:xz"
         with tarfile.open(src, mode) as tf:
+            pending_links: list[tuple[Path, Path, bool]] = []
             for member in tf.getmembers():
                 if not member.name:
                     continue
-                stripped = strip_name(member.name, strip_components)
-                if not stripped:
+                stripped_member = stripped_tar_member(member, strip_components)
+                if stripped_member is None:
                     continue
-                target = dest / stripped
-                if member.isdir():
+                target = dest / stripped_member.name
+                if stripped_member.isdir():
                     target.mkdir(parents=True, exist_ok=True)
-                    continue
+                elif stripped_member.isfile():
+                    extract_tar_member_file(tf, member, target)
+                elif stripped_member.issym() or stripped_member.islnk():
+                    link = (target, stripped_member.linkname, stripped_member.issym())
+                    if not materialize_tar_link(
+                        dest, link[0], link[1], symlink=link[2]
+                    ):
+                        pending_links.append(link)
 
-                parent = target.parent
-                parent.mkdir(parents=True, exist_ok=True)
-                extracted = tf.extractfile(member)
-                if extracted is None:
-                    continue
-                with extracted, target.open("wb") as out:
-                    shutil.copyfileobj(extracted, out)
-                if member.mode & 0o111:
-                    target.chmod(target.stat().st_mode | 0o755)
+            for link in pending_links:
+                materialize_tar_link(dest, link[0], link[1], symlink=link[2])
     elif archive == "zip":
         with zipfile.ZipFile(src) as zf:
             for member in zf.infolist():

--- a/state/upstream-release-bot.json
+++ b/state/upstream-release-bot.json
@@ -1,5 +1,64 @@
 {
-  "schema_version": 1,
+  "packages": {
+    "clang": {
+      "last_checked_at": "2026-05-06T18:31:32Z",
+      "last_generated_at": "2026-05-06T18:29:38Z",
+      "last_successful_version": "21.1.8-1",
+      "latest_seen_version": "21.1.8-1",
+      "source_identity": "github_releases:xpack-dev-tools/clang-xpack",
+      "source_kind": "github_releases"
+    },
+    "cmake": {
+      "last_checked_at": "2026-05-06T18:29:35Z",
+      "last_generated_at": "2026-05-06T18:29:35Z",
+      "last_successful_version": "4.3.2",
+      "latest_seen_version": "4.3.2",
+      "source_identity": "github_releases:Kitware/CMake",
+      "source_kind": "github_releases"
+    },
+    "fish": {
+      "last_checked_at": "2026-05-06T18:29:33Z",
+      "last_generated_at": "2026-05-06T18:29:33Z",
+      "last_successful_version": "4.7.0",
+      "latest_seen_version": "4.7.0",
+      "source_identity": "github_releases:fish-shell/fish-shell",
+      "source_kind": "github_releases"
+    },
+    "gcc": {
+      "last_checked_at": "2026-05-06T18:31:33Z",
+      "last_generated_at": "2026-05-06T18:29:41Z",
+      "last_successful_version": "15.2.0-1",
+      "latest_seen_version": "15.2.0-1",
+      "source_identity": "github_releases:xpack-dev-tools/gcc-xpack",
+      "source_kind": "github_releases"
+    },
+    "ninja": {
+      "last_checked_at": "2026-05-06T18:29:34Z",
+      "last_generated_at": "2026-05-06T18:29:34Z",
+      "last_successful_version": "1.13.2",
+      "latest_seen_version": "1.13.2",
+      "source_identity": "github_releases:ninja-build/ninja",
+      "source_kind": "github_releases"
+    },
+    "nushell": {
+      "last_checked_at": "2026-05-06T18:29:31Z",
+      "last_generated_at": "2026-05-06T18:29:31Z",
+      "last_successful_version": "0.112.2",
+      "latest_seen_version": "0.112.2",
+      "source_identity": "github_releases:nushell/nushell",
+      "source_kind": "github_releases"
+    },
+    "powershell": {
+      "last_checked_at": "2026-05-06T18:29:32Z",
+      "last_generated_at": "2026-05-06T18:29:32Z",
+      "last_successful_version": "7.6.1",
+      "latest_seen_version": "7.6.1",
+      "source_identity": "github_releases:PowerShell/PowerShell",
+      "source_kind": "github_releases"
+    }
+  },
+  "quarantine": {},
+  "schema_version": 2,
   "sources": {
     "github_releases:BurntSushi/ripgrep": {
       "etag": "\"ea00f8f1cc306c039a694edc219a7767d92476bc442cadfc1f36ad594e6abcfd\"",
@@ -31,10 +90,26 @@
       "last_checked_at": "2026-05-05T11:40:15Z",
       "latest_version": "2.4.1"
     },
+    "github_releases:Kitware/CMake": {
+      "etag": "W/\"dcfc1a89ad4611c11841955f37b850c3f079fce224cc71a17c633949414ee100\"",
+      "last_checked_at": "2026-05-06T18:29:35Z",
+      "latest_seen_version": "4.3.2",
+      "latest_version": "4.3.2",
+      "source_identity": "github_releases:Kitware/CMake",
+      "source_kind": "github_releases"
+    },
     "github_releases:Kong/insomnia": {
       "etag": "\"8fa75e754e42d10d4869fdd2da178a3d39cf48a06e8f390b259a75bc95c6d033\"",
       "last_checked_at": "2026-05-05T11:39:26Z",
       "latest_version": "12.5.0"
+    },
+    "github_releases:PowerShell/PowerShell": {
+      "etag": "W/\"eb101e6988d771eb709072415290cb09e2e3f00213977fc2ba99e1501c68c741\"",
+      "last_checked_at": "2026-05-06T18:29:32Z",
+      "latest_seen_version": "7.6.1",
+      "latest_version": "7.6.1",
+      "source_identity": "github_releases:PowerShell/PowerShell",
+      "source_kind": "github_releases"
     },
     "github_releases:Yakitrak/notesmd-cli": {
       "etag": "\"7b9e186781a45b086f2e9d6452a1b49f05be41195ea79f2b32be820e42a42d82\"",
@@ -55,6 +130,11 @@
       "etag": "\"d8a04945e1efb828f4069bc3ad2d080fceccd9aa2e7f2c20e738c0680fca005c\"",
       "last_checked_at": "2026-05-05T11:39:55Z",
       "latest_version": "5.4.3"
+    },
+    "github_releases:anomalyco/opencode": {
+      "etag": "\"64af373b9102be56aa1d7dfea9042b2ee87d0ff99fdead70fda651229285191c\"",
+      "last_checked_at": "2026-05-05T11:39:51Z",
+      "latest_version": "1.14.39"
     },
     "github_releases:aome510/spotify-player": {
       "etag": "\"6fa8c3fd4eeb321d581bb5caf5c037aaa1b4a3936b844c81c3e267a95889d7b6\"",
@@ -186,6 +266,14 @@
       "last_checked_at": "2026-05-05T11:39:11Z",
       "latest_version": "2.62.1"
     },
+    "github_releases:fish-shell/fish-shell": {
+      "etag": "W/\"3dc8eb635e782d3449cfe0f74b949693f47eb3dcd3fb3f20128f54af4b979c53\"",
+      "last_checked_at": "2026-05-06T18:29:33Z",
+      "latest_seen_version": "4.7.0",
+      "latest_version": "4.7.0",
+      "source_identity": "github_releases:fish-shell/fish-shell",
+      "source_kind": "github_releases"
+    },
     "github_releases:fluxcd/flux2": {
       "etag": "\"d0164ebac18bbb7e529866853dc349c17f7e6bfce36f6b274a9caa3351cbe1f0\"",
       "last_checked_at": "2026-05-05T11:39:13Z",
@@ -305,6 +393,22 @@
       "last_checked_at": "2026-05-05T11:39:47Z",
       "latest_version": "0.12.2"
     },
+    "github_releases:ninja-build/ninja": {
+      "etag": "W/\"1b336f3a73df671bbc66e971ad49ce44ed2ca83ec27fa873a1e8e67c02e4fbb0\"",
+      "last_checked_at": "2026-05-06T18:29:34Z",
+      "latest_seen_version": "1.13.2",
+      "latest_version": "1.13.2",
+      "source_identity": "github_releases:ninja-build/ninja",
+      "source_kind": "github_releases"
+    },
+    "github_releases:nushell/nushell": {
+      "etag": "W/\"90f1844014ac76b017296c50f1cf59dcccc3bc8132c0799a956cbec01ef0833f\"",
+      "last_checked_at": "2026-05-06T18:29:31Z",
+      "latest_seen_version": "0.112.2",
+      "latest_version": "0.112.2",
+      "source_identity": "github_releases:nushell/nushell",
+      "source_kind": "github_releases"
+    },
     "github_releases:obsidianmd/obsidian-releases": {
       "etag": "\"ce91aba18bd98eec3d900b7ccbe2d0551518b9122ab214b9a6bb8bf6d5c23b84\"",
       "last_checked_at": "2026-05-05T11:39:49Z",
@@ -370,11 +474,6 @@
       "last_checked_at": "2026-05-05T11:38:57Z",
       "latest_version": "0.13.1"
     },
-    "github_releases:anomalyco/opencode": {
-      "etag": "\"64af373b9102be56aa1d7dfea9042b2ee87d0ff99fdead70fda651229285191c\"",
-      "last_checked_at": "2026-05-05T11:39:51Z",
-      "latest_version": "1.14.39"
-    },
     "github_releases:starship/starship": {
       "etag": "\"97788814091e9c29957c8851b2c4c4b52f1584d40370b15986596c764d8174fb\"",
       "last_checked_at": "2026-05-05T11:40:14Z",
@@ -409,6 +508,22 @@
       "etag": "\"37c7dec14e44f90141665746fe4022c16d8788076b919833ec02ae2cefac8b8f\"",
       "last_checked_at": "2026-05-05T11:40:24Z",
       "latest_version": "2.5.1"
+    },
+    "github_releases:xpack-dev-tools/clang-xpack": {
+      "etag": "W/\"ee99837c48c1de5d3ba479d00e143dbaf0b8fdc28c606902f97eb4cd4e05afb1\"",
+      "last_checked_at": "2026-05-06T18:31:32Z",
+      "latest_seen_version": "21.1.8-1",
+      "latest_version": "21.1.8-1",
+      "source_identity": "github_releases:xpack-dev-tools/clang-xpack",
+      "source_kind": "github_releases"
+    },
+    "github_releases:xpack-dev-tools/gcc-xpack": {
+      "etag": "W/\"197f5eba5816044052ebc8a7b505f7550d9e2918595bdac63c7971b78fe7263d\"",
+      "last_checked_at": "2026-05-06T18:31:33Z",
+      "latest_seen_version": "15.2.0-1",
+      "latest_version": "15.2.0-1",
+      "source_identity": "github_releases:xpack-dev-tools/gcc-xpack",
+      "source_kind": "github_releases"
     },
     "github_releases:yt-dlp/yt-dlp": {
       "etag": "\"843f4682017102f35d540be7ff8871c589527928cbca7c24f91ebf2a6ed2a351\"",

--- a/tests/test_registry_generate_manifest.py
+++ b/tests/test_registry_generate_manifest.py
@@ -207,6 +207,42 @@ class RegistryGenerateManifestTests(unittest.TestCase):
         self.assertIn('host = "kubectl"', package_text)
         self.assertIn('[[integrations]]\nkind = "path_plugin"', release_text)
 
+    def test_generates_package_text_preserves_policy_arrays(self) -> None:
+        doc = {
+            "name": "clang",
+            "license": "Apache-2.0 WITH LLVM-exception",
+            "homepage": "https://xpack.github.io/dev-tools/clang/",
+            "provides": ["c-compiler", "cxx-compiler", "llvm"],
+            "conflicts": {"old-clang": "*"},
+            "replaces": {"llvm-toolchain": "<2.0.0"},
+            "source": {
+                "release": {
+                    "kind": "github_releases",
+                    "repo": "xpack-dev-tools/clang-xpack",
+                    "tag_prefix": "v",
+                },
+                "version": {"kind": "github_tag"},
+                "checksum": {"kind": "url_sha256", "url_template": "{url}.sha"},
+                "asset": {"kind": "release_asset_url"},
+            },
+            "artifacts": [
+                {
+                    "target": "x86_64-unknown-linux-gnu",
+                    "asset": "xpack-clang-{version}-linux-x64.tar.gz",
+                    "archive": "tar.gz",
+                    "strip_components": 1,
+                    "binaries": [{"name": "clang", "path": "bin/clang"}],
+                }
+            ],
+        }
+
+        package_text = self.generator.render_package_text(doc)
+
+        self.assertIn('provides = ["c-compiler", "cxx-compiler", "llvm"]', package_text)
+        self.assertIn('[conflicts]\nold-clang = "*"', package_text)
+        self.assertIn('[replaces]\nllvm-toolchain = "<2.0.0"', package_text)
+        self.assertLess(package_text.index("provides ="), package_text.index("[source.release]"))
+
     def test_download_retries_transient_http_error(self) -> None:
         with tempfile.TemporaryDirectory(prefix="manifest-gen-") as tmp:
             dest = Path(tmp) / "artifact.tar.gz"

--- a/tests/test_registry_generate_manifest.py
+++ b/tests/test_registry_generate_manifest.py
@@ -243,6 +243,37 @@ class RegistryGenerateManifestTests(unittest.TestCase):
         self.assertIn('[replaces]\nllvm-toolchain = "<2.0.0"', package_text)
         self.assertLess(package_text.index("provides ="), package_text.index("[source.release]"))
 
+    def test_package_policy_rejects_malformed_conflicts(self) -> None:
+        doc = {
+            "name": "clang",
+            "license": "Apache-2.0 WITH LLVM-exception",
+            "homepage": "https://xpack.github.io/dev-tools/clang/",
+            "conflicts": ["old-clang"],
+            "source": {
+                "release": {
+                    "kind": "github_releases",
+                    "repo": "xpack-dev-tools/clang-xpack",
+                },
+                "version": {"kind": "github_tag"},
+                "checksum": {"kind": "url_sha256", "url_template": "{url}.sha"},
+                "asset": {"kind": "release_asset_url"},
+            },
+            "artifacts": [
+                {
+                    "target": "x86_64-unknown-linux-gnu",
+                    "asset": "xpack-clang-{version}-linux-x64.tar.gz",
+                    "archive": "tar.gz",
+                    "binaries": [{"name": "clang", "path": "bin/clang"}],
+                }
+            ],
+        }
+
+        with self.assertRaisesRegex(
+            self.generator.GenerateError,
+            "package policy field conflicts must be a table",
+        ):
+            self.generator.render_package_text(doc)
+
     def test_download_retries_transient_http_error(self) -> None:
         with tempfile.TemporaryDirectory(prefix="manifest-gen-") as tmp:
             dest = Path(tmp) / "artifact.tar.gz"

--- a/tests/test_registry_smoke_install.py
+++ b/tests/test_registry_smoke_install.py
@@ -247,6 +247,38 @@ class RegistrySmokeInstallTests(unittest.TestCase):
             self.assertEqual((install_root / "bin" / "clang").read_bytes(), b"clang")
             self.assertTrue((install_root / "bin" / "llvm-ml").exists())
 
+    def test_stripped_tar_member_clones_without_replace(self) -> None:
+        member = tarfile.TarInfo("root/bin/tool")
+        member.type = tarfile.SYMTYPE
+        member.linkname = "tool-real"
+        member.mode = 0o755
+        member.size = 123
+        member.mtime = 456
+        member.uid = 7
+        member.gid = 8
+        member.uname = "builder"
+        member.gname = "builders"
+        member.devmajor = 9
+        member.devminor = 10
+        member.pax_headers = {"comment": "metadata"}
+
+        stripped = self.smoke.stripped_tar_member(member, 1)
+
+        self.assertIsNot(stripped, member)
+        self.assertEqual(stripped.name, "bin/tool")
+        self.assertEqual(stripped.type, tarfile.SYMTYPE)
+        self.assertEqual(stripped.linkname, "tool-real")
+        self.assertEqual(stripped.mode, 0o755)
+        self.assertEqual(stripped.size, 123)
+        self.assertEqual(stripped.mtime, 456)
+        self.assertEqual(stripped.uid, 7)
+        self.assertEqual(stripped.gid, 8)
+        self.assertEqual(stripped.uname, "builder")
+        self.assertEqual(stripped.gname, "builders")
+        self.assertEqual(stripped.devmajor, 9)
+        self.assertEqual(stripped.devminor, 10)
+        self.assertEqual(stripped.pax_headers, {"comment": "metadata"})
+
     def test_download_retries_transient_http_error(self) -> None:
         with tempfile.TemporaryDirectory(prefix="smoke-test-") as tmp:
             dest = Path(tmp) / "payload"

--- a/tests/test_registry_smoke_install.py
+++ b/tests/test_registry_smoke_install.py
@@ -225,6 +225,28 @@ class RegistrySmokeInstallTests(unittest.TestCase):
         self.assertTrue(ok, msg=message)
         self.assertIn("demo@1.0.0", message)
 
+    def test_tar_extraction_rewrites_stripped_hardlink_targets(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="smoke-test-") as tmp:
+            tmp_path = Path(tmp)
+            payload_path = tmp_path / "payload.tar.gz"
+            install_root = tmp_path / "install"
+            with tarfile.open(payload_path, "w:gz") as tf:
+                binary = b"clang"
+                clang = tarfile.TarInfo("xpack-clang-1/bin/clang")
+                clang.size = len(binary)
+                clang.mode = 0o755
+                tf.addfile(clang, io.BytesIO(binary))
+
+                llvm_ml = tarfile.TarInfo("xpack-clang-1/bin/llvm-ml")
+                llvm_ml.type = tarfile.LNKTYPE
+                llvm_ml.linkname = "xpack-clang-1/bin/clang"
+                tf.addfile(llvm_ml)
+
+            self.smoke.extract_archive(payload_path, install_root, "tar.gz", 1)
+
+            self.assertEqual((install_root / "bin" / "clang").read_bytes(), b"clang")
+            self.assertTrue((install_root / "bin" / "llvm-ml").exists())
+
     def test_download_retries_transient_http_error(self) -> None:
         with tempfile.TemporaryDirectory(prefix="smoke-test-") as tmp:
             dest = Path(tmp) / "payload"

--- a/tests/test_upstream_release_bot.py
+++ b/tests/test_upstream_release_bot.py
@@ -1564,21 +1564,11 @@ class UpstreamReleaseBotTests(unittest.TestCase):
                     "git",
                     "push",
                     "--force-with-lease=refs/heads/upstream-release/rolling:abc123",
+                    "-u",
                     "origin",
-                    "origin/main:refs/heads/upstream-release/rolling",
+                    "upstream-release/rolling",
                 ]
             ),
-        )
-        self.assertIn(
-            [
-                "git",
-                "push",
-                "--force-with-lease=refs/heads/upstream-release/rolling:abc123",
-                "-u",
-                "origin",
-                "upstream-release/rolling",
-            ],
-            calls,
         )
 
     def test_open_or_update_rolling_pr_fetches_branch_before_force_with_lease(self) -> None:


### PR DESCRIPTION
## Summary

Adds a high-value boundary-test package set to the registry:

- nushell
- powershell
- fish
- ninja
- cmake
- clang
- gcc

Also hardens registry validation so package changes are exercised through Crosspack itself, not only through registry-local schema and smoke scripts.

## Why

Registry-local validation accepted package metadata that Crosspack could not actually consume. The new Crosspack-native registry check signs a temporary registry copy, points Crosspack at it via `--registry-root`, and runs `crosspack info` plus dry-run installs for changed packages. This catches runtime/schema drift before merge.

## Validation

- `python3 -m unittest tests.test_registry_generate_manifest tests.test_registry_smoke_install tests.test_upstream_release_bot -v`
- `python3 scripts/registry-validate-source.py packages/nushell.toml packages/powershell.toml packages/fish.toml packages/ninja.toml packages/cmake.toml packages/clang.toml packages/gcc.toml`
- `python3 scripts/registry-validate.py --allow-missing-signatures ...`
- `python3 scripts/registry-smoke-install.py --require-runner-target ...`
- `registry/scripts/registry-crosspack-native-check.sh ...`
- standalone registry checkout with explicit `CROSSPACK_REPO_ROOT` and `CROSSPACK_NATIVE_TARGETS='x86_64-unknown-linux-gnu x86_64-pc-windows-msvc'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-platform manifests for Clang, CMake, Fish, GCC, Ninja, Nushell, PowerShell and corresponding release entries.
  * Added PR validation for Crosspack native checks.

* **Bug Fixes / Improvements**
  * Improved archive extraction handling for symlinks and hardlinks.

* **Tests**
  * Added tests for package policy rendering and tar extraction/hardlink behavior.

* **Chores**
  * Updated upstream release tracking and CI workflow configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->